### PR TITLE
Increment app version to `0.2.2`, enable dynamic `versionCode` handli…

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -58,6 +58,8 @@ jobs:
       # 🔹 App Bundle (Release) erstellen
       - name: Build Release App Bundle with Direct Credentials
         env:
+          # Setzt den versionCode dynamisch auf die Build-Nummer des Workflows
+          VERSION_CODE: ${{ github.run_number }}
           # Mappe die Secrets zu den Gradle Environment Variables
           ORG_GRADLE_PROJECT_android.signing.storeFile: release.keystore
           ORG_GRADLE_PROJECT_android.signing.storePassword: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -65,6 +67,7 @@ jobs:
           ORG_GRADLE_PROJECT_android.signing.keyPassword: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
           echo "Starting release appbundle build using direct credentials..."
+          # Der Build-Befehl muss nicht geändert werden, da Gradle die Variable automatisch aufnimmt
           flutter build appbundle --release
           echo "Build command finished."
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,18 +44,18 @@ android {
     }
 
     defaultConfig {
-        // TODO: ÄNDERN SIE DIES! Dies muss eine einzigartige ID für Ihre App sein.
         applicationId "app.work_time_manager"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
+        // Prioritize environment variable for CI, otherwise use local properties.
+        versionCode System.getenv("VERSION_CODE") != null ? System.getenv("VERSION_CODE").toInteger() : flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
 
     signingConfigs {
         release {
-            // Diese Konfiguration liest die Signatur-Details aus den Umgebungsvariablen,
-            // die in der GitHub Action gesetzt werden.
+            // This configuration reads the signature details from the environment variables
+            // set in the GitHub Action.
             if (System.getenv("ORG_GRADLE_PROJECT_android.signing.storeFile") != null) {
                 storeFile file(System.getenv("ORG_GRADLE_PROJECT_android.signing.storeFile"))
                 storePassword System.getenv("ORG_GRADLE_PROJECT_android.signing.storePassword")
@@ -67,10 +67,7 @@ android {
 
     buildTypes {
         release {
-            // Verwendet die oben definierte 'release' Signatur-Konfiguration.
             signingConfig signingConfigs.release
-
-            // Aktiviert Code-Verkleinerung, Verschleierung und Optimierung für den Release-Build.
             minifyEnabled true
             shrinkResources true
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
…ng, and refine Gradle configuration

- **Versioning**:
  - Bumped version from `0.2.1` to `0.2.2` in `pubspec.yaml`.
  - Introduced dynamic `versionCode` assignment using CI workflow run number.

- **Gradle Config**:
  - Prioritized CI environment variables for `versionCode`.
  - Streamlined comments and removed redundant entries in `build.gradle`.

- **Workflow Updates**:
  - Added `VERSION_CODE` environment variable in GitHub Actions for dynamic build numbering.