### PR TITLE
Update to `0.2.3`, change home screen to `HomeScreen`, and refine initialization logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,5 +200,6 @@ fabric.properties
 
 firebase.json
 google-services.json
+*.pem
 
 # End of https://www.toptal.com/developers/gitignore/api/flutter,androidstudio

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,14 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_work_time/presentation/screens/auth_gate.dart';
+import 'package:flutter_work_time/presentation/screens/home_screen.dart'; // Geändert
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_work_time/app_check_initializer.dart';
 
-import 'core/config/google_sign_in_config.dart'; // Import für GoogleSignInConfig hinzugefügt
+import 'core/config/google_sign_in_config.dart'; 
 import 'core/providers/providers.dart';
 import 'core/theme/app_theme.dart';
 import 'firebase_options.dart';
@@ -17,13 +17,9 @@ import 'presentation/view_models/theme_view_model.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Initialisiere die Datumsformatierung für die deutsche Sprache.
   await initializeDateFormatting('de_DE', null);
   Intl.defaultLocale = 'de_DE';
 
-  // GoogleSignIn initialisieren mit dem serverClientId
-  // Dies sollte vor der Firebase-Initialisierung oder anderen Abhängigkeiten erfolgen,
-  // die möglicherweise auf ein konfiguriertes GoogleSignIn angewiesen sind.
   await GoogleSignIn.instance.initialize(
     serverClientId: GoogleSignInConfig.serverClientId,
   );
@@ -32,7 +28,6 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  // App Check aktivieren (Android: Debug/Release-abhängig)
   await AppBootstrap.ensureInitializedForEnv();
 
   final prefs = await SharedPreferences.getInstance();
@@ -60,7 +55,7 @@ class MyApp extends ConsumerWidget {
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: themeMode,
-      home: const AuthGate(),
+      home: const HomeScreen(), // Geändert von AuthGate zu HomeScreen
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.2.2
+version: 0.2.3
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
- **Version Bump**:
    - Incremented app version from `0.2.2` to `0.2.3` in `pubspec.yaml`.

- **Home Screen Update**:
    - Replaced `AuthGate` with `HomeScreen` as the entry point.

- **Code Cleanup**:
    - Removed redundant initialization comments for readability.

- **Git Ignore Update**:
    - Excluded `.pem` files in `.gitignore`.  