### PR TITLE
Refactor: Implement delete work entry functionality

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
 
     defaultConfig {
         applicationId "app.work_time_manager"
-        minSdkVersion 31//flutter.minSdkVersion
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         // Prioritize environment variable for CI, otherwise use local properties.
         versionCode System.getenv("VERSION_CODE") != null ? System.getenv("VERSION_CODE").toInteger() : flutterVersionCode.toInteger()

--- a/lib/core/providers/providers.dart
+++ b/lib/core/providers/providers.dart
@@ -85,6 +85,11 @@ class NoOpWorkRepository implements WorkRepository {
   Future<List<WorkEntryEntity>> getWorkEntriesForMonth(int year, int month) async {
     return [];
   }
+
+  @override
+  Future<void> deleteWorkEntry(String entryId) async {
+    // No-op
+  }
 }
 
 final workRepositoryProvider = Provider<WorkRepository>((ref) {

--- a/lib/data/datasources/remote/firestore_datasource.dart
+++ b/lib/data/datasources/remote/firestore_datasource.dart
@@ -34,6 +34,9 @@ abstract class FirestoreDataSource {
       int year,
       int month,
       );
+
+  /// Löscht einen Arbeitseintrag für einen bestimmten Benutzer anhand der Eintrags-ID.
+  Future<void> deleteWorkEntry(String userId, String entryId);
 }
 
 /// Die konkrete Implementierung der FirestoreDataSource.
@@ -215,5 +218,11 @@ class FirestoreDataSourceImpl implements FirestoreDataSource {
 
     // Wandle die resultierenden Dokumente in eine Liste von Models um.
     return querySnapshot.docs.map((doc) => WorkEntryModel.fromFirestore(doc)).toList();
+  }
+
+  @override
+  Future<void> deleteWorkEntry(String userId, String entryId) async {
+    final docRef = _getWorkEntryDocRef(userId, entryId);
+    await docRef.delete();
   }
 }

--- a/lib/data/repositories/work_repository_impl.dart
+++ b/lib/data/repositories/work_repository_impl.dart
@@ -34,4 +34,9 @@ class WorkRepositoryImpl implements WorkRepository {
     // Die von der Datenquelle zurückgegebenen Models sind bereits Entities.
     return await dataSource.getWorkEntriesForMonth(userId, year, month);
   }
+
+  @override
+  Future<void> deleteWorkEntry(String entryId) async {
+    await dataSource.deleteWorkEntry(userId, entryId);
+  }
 }

--- a/lib/domain/repositories/work_repository.dart
+++ b/lib/domain/repositories/work_repository.dart
@@ -27,4 +27,7 @@ abstract class WorkRepository {
   ///
   /// Nützlich für die Kalenderansicht und Monatsberichte.
   Future<List<WorkEntryEntity>> getWorkEntriesForMonth(int year, int month);
+
+  /// Löscht einen Arbeitseintrag anhand seiner ID.
+  Future<void> deleteWorkEntry(String entryId);
 }

--- a/lib/presentation/view_models/dashboard_view_model.dart
+++ b/lib/presentation/view_models/dashboard_view_model.dart
@@ -36,6 +36,11 @@ class NoOpWorkRepository implements WorkRepository {
 
   @override
   Future<void> saveWorkEntry(WorkEntryEntity entry) async {}
+
+  @override
+  Future<void> deleteWorkEntry(String entryId) async {
+    // No-op
+  }
 }
 
 class NoOpOvertimeRepository implements OvertimeRepository {

--- a/lib/presentation/view_models/reports_view_model.dart
+++ b/lib/presentation/view_models/reports_view_model.dart
@@ -35,6 +35,11 @@ class DummyWorkRepository implements WorkRepository {
       manualOvertime: Duration.zero,
     );
   }
+
+  @override
+  Future<void> deleteWorkEntry(String entryId) async {
+    // Im Dummy-Repository passiert nichts
+  }
 }
 
 final reportsViewModelProvider =
@@ -80,6 +85,21 @@ class ReportsViewModel extends StateNotifier<ReportsState> {
         weeklyReportState: _calculateWeeklyReport(now),
         monthlyReportState: _calculateMonthlyReport(),
       );
+    }
+  }
+
+  Future<void> deleteWorkEntry(String entryId) async {
+    state = state.copyWith(isLoading: true);
+    try {
+      await _workRepository.deleteWorkEntry(entryId);
+      // Nach dem Löschen die Einträge für den aktuellen Monat neu laden
+      final selectedDate = state.selectedDay ?? DateTime.now();
+      await _loadWorkEntriesForMonth(selectedDate.year, selectedDate.month);
+    } catch (e, stackTrace) {
+      print('Fehler beim Löschen des Arbeitseintrags: $e');
+      print('Stacktrace: $stackTrace');
+      // Setze den Ladezustand zurück, auch wenn ein Fehler auftritt
+      state = state.copyWith(isLoading: false);
     }
   }
 


### PR DESCRIPTION
Refactor: Implement delete work entry functionality and update `minSdkVersion`

- **Feature**:
  - Implemented the ability to delete work entries.
    - Added `deleteWorkEntry` methods to `WorkRepository`, `WorkRepositoryImpl`, `FirestoreDataSource`, and `ReportsViewModel`.
    - Integrated delete functionality into `ReportsPage` with a confirmation dialog.
    - Updated `DailyReportView` and `DayEntriesBottomSheet` to include delete buttons and handle deletion.
- **Android**:
  - Changed `minSdkVersion` from hardcoded `31` to `flutter.minSdkVersion` in `android/app/build.gradle`.
- **Refactor**:
  - Modified `_showEditWorkEntryModal` in `ReportsPage` to accept `BuildContext`.
  - Updated `DayEntriesBottomSheet` to refresh data after editing or deleting entries and to correctly handle context for modals and dialogs.
  - Ensured `selectDate` is called appropriately to load data for the `DayEntriesBottomSheet`.
  - Added no-op `deleteWorkEntry` implementations in `NoOpWorkRepository` (within `providers.dart`) and `NoOpWorkRepository` (within `dashboard_view_model.dart`).