### PR TITLE
Update report logic and app version

### DIFF
--- a/lib/presentation/screens/reports_page.dart
+++ b/lib/presentation/screens/reports_page.dart
@@ -40,10 +40,11 @@ class _ReportsPageState extends ConsumerState<ReportsPage>
 
     // Initiale Daten laden
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final now = DateTime.now();
+      // Verwende loadCurrentMonthData() statt onMonthChanged(),
+      // um den aktuellen Tag beizubehalten (nicht auf den 1. zu springen)
       ref
           .read(reportsViewModelProvider.notifier)
-          .onMonthChanged(DateTime(now.year, now.month, 1));
+          .loadCurrentMonthData();
 
       // Prüfe ob ein Tab-Index nach Login wartet
       final pendingTabIndex = ref.read(pendingReportTabIndexProvider);

--- a/lib/presentation/view_models/reports_view_model.dart
+++ b/lib/presentation/view_models/reports_view_model.dart
@@ -170,6 +170,19 @@ class ReportsViewModel extends StateNotifier<ReportsState> {
     _loadWorkEntriesForMonth(newMonth.year, newMonth.month);
   }
 
+  /// Lädt Daten für den aktuellen Monat ohne selectedDay zu ändern
+  /// Wird beim initialen Laden verwendet, um den aktuellen Tag beizubehalten
+  void loadCurrentMonthData() {
+    if (!mounted) return;
+
+    final now = DateTime.now();
+    final normalizedMonth = DateTime(now.year, now.month, 1);
+
+    // Aktualisiere nur selectedMonth, behalte selectedDay (sollte bereits auf heute gesetzt sein)
+    state = state.copyWith(selectedMonth: normalizedMonth);
+    _loadWorkEntriesForMonth(now.year, now.month);
+  }
+
   Future<void> _loadWorkEntriesForMonth(int year, int month) async {
     if (!mounted) return;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.6.2
+version: 0.6.3
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
- Refactored `onMonthChanged` to use a new method `loadCurrentMonthData` for better handling of the current day when data is loaded.
- Bumped application version to 0.6.3 in `pubspec.yaml`.

close #53