### PR TITLE
Make settings user-specific and enhance debugging

### DIFF
--- a/lib/data/repositories/settings_repository_impl.dart
+++ b/lib/data/repositories/settings_repository_impl.dart
@@ -7,15 +7,18 @@ import '../datasources/remote/firestore_datasource.dart';
 import '../models/work_entry_model.dart';
 
 class SettingsRepositoryImpl implements SettingsRepository {
+  // Theme ist global (nicht userId-spezifisch)
   static const String _themeModeKey = 'theme_mode';
-  static const String _targetHoursKey = 'target_weekly_hours';
-  static const String _workdaysPerWeekKey = 'workdays_per_week';
 
   final SharedPreferences _prefs;
   final FirestoreDataSource _firestoreDataSource;
   final String _userId;
 
   SettingsRepositoryImpl(this._prefs, this._firestoreDataSource, this._userId);
+
+  // Generiere userId-spezifische Keys für Einstellungen
+  String get _targetHoursKey => 'target_weekly_hours_$_userId';
+  String get _workdaysPerWeekKey => 'workdays_per_week_$_userId';
 
   @override
   ThemeMode getThemeMode() {
@@ -36,21 +39,27 @@ class SettingsRepositoryImpl implements SettingsRepository {
 
   @override
   double getTargetWeeklyHours() {
-    return _prefs.getDouble(_targetHoursKey) ?? 40.0;
+    final value = _prefs.getDouble(_targetHoursKey);
+    print('[SettingsRepository] getTargetWeeklyHours for user $_userId: $value');
+    return value ?? 40.0;
   }
 
   @override
   Future<void> setTargetWeeklyHours(double hours) async {
+    print('[SettingsRepository] setTargetWeeklyHours for user $_userId: $hours');
     await _prefs.setDouble(_targetHoursKey, hours);
   }
 
   @override
   int getWorkdaysPerWeek() {
-    return _prefs.getInt(_workdaysPerWeekKey) ?? 5;
+    final value = _prefs.getInt(_workdaysPerWeekKey);
+    print('[SettingsRepository] getWorkdaysPerWeek for user $_userId: $value');
+    return value ?? 5;
   }
 
   @override
   Future<void> setWorkdaysPerWeek(int days) async {
+    print('[SettingsRepository] setWorkdaysPerWeek for user $_userId: $days');
     await _prefs.setInt(_workdaysPerWeekKey, days);
   }
 

--- a/lib/presentation/view_models/settings_view_model.dart
+++ b/lib/presentation/view_models/settings_view_model.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/providers/providers.dart';
-import '../../data/repositories/settings_repository_impl.dart';
+import '../../core/providers/providers.dart' as core_providers;
 import '../../domain/entities/settings_entity.dart';
 import '../../domain/entities/work_entry_entity.dart';
 import '../../domain/repositories/settings_repository.dart';
@@ -10,7 +9,7 @@ import '../../domain/usecases/overtime_usecases.dart';
 import '../state/settings_state.dart';
 import 'dashboard_view_model.dart' show getOvertimeProvider, setOvertimeProvider, dashboardViewModelProvider;
 
-// Temporary No-op repository
+// Temporary No-op repository - wird nur für Fallback-Fälle benötigt
 class NoOpSettingsRepository implements SettingsRepository {
   @override
   ThemeMode getThemeMode() => ThemeMode.system;
@@ -24,7 +23,7 @@ class NoOpSettingsRepository implements SettingsRepository {
   int getWorkdaysPerWeek() => 5;
   @override
   Future<void> setWorkdaysPerWeek(int days) async {}
-  
+
   @override
   Future<List<WorkEntryEntity>> getAllOldWorkEntries() async => [];
 
@@ -34,23 +33,6 @@ class NoOpSettingsRepository implements SettingsRepository {
   @override
   Future<void> deleteAllOldWorkEntries(List<String> entryIds) async {}
 }
-
-final settingsRepositoryProvider = Provider<SettingsRepository>((ref) {
-  try {
-    final firestoreDataSource = ref.watch(firestoreDataSourceProvider);
-    final userId = ref.watch(firebaseAuthProvider).currentUser?.uid;
-    if (userId == null) {
-      return NoOpSettingsRepository();
-    }
-    return SettingsRepositoryImpl(
-      ref.watch(sharedPreferencesProvider),
-      firestoreDataSource,
-      userId,
-    );
-  } catch (e) {
-    return NoOpSettingsRepository();
-  }
-});
 
 class SettingsViewModel extends StateNotifier<AsyncValue<SettingsState>> {
   final GetOvertime _getOvertime;
@@ -133,6 +115,6 @@ final settingsViewModelProvider =
   return SettingsViewModel(
     ref.watch(getOvertimeProvider),
     ref.watch(setOvertimeProvider),
-    ref.watch(settingsRepositoryProvider),
+    ref.watch(core_providers.settingsRepositoryProvider),
   );
 });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.6.4
+version: 0.6.5
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
### Changes Made
- Refactored `SettingsRepositoryImpl` to use user-specific keys for `target_weekly_hours` and `workdays_per_week`.
- Added debug logs for better visibility into user-specific settings retrieval and saving.
- Made import adjustments in `settingsRepositoryProvider` for consistency.
- Bumped app version to `0.6.5` in `pubspec.yaml`.

close #60