### PR TITLE
Update app metadata for release 0.6.7

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="work_time_manager"
+        android:label="Work Time Manager"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
         <activity

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.6.6
+version: 0.6.7
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
- Updated the app name to "Work Time Manager" in `AndroidManifest.xml`.
- Bumped the app version to 0.6.7 in `pubspec.yaml`.

close #55