### PR TITLE
Add Privacy Policy dialog and enforce acceptance before login

### DIFF
--- a/lib/presentation/screens/login_page.dart
+++ b/lib/presentation/screens/login_page.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -6,26 +7,66 @@ import '../../data/repositories/hybrid_overtime_repository_impl.dart';
 import '../../domain/services/data_sync_service.dart';
 import '../view_models/auth_view_model.dart';
 import '../view_models/dashboard_view_model.dart' as dashboard_vm;
+import '../widgets/privacy_policy_dialog.dart';
 import 'home_screen.dart';
 
-class LoginPage extends ConsumerWidget {
+class LoginPage extends ConsumerStatefulWidget {
   final bool returnToReports;
   const LoginPage({this.returnToReports = false, Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends ConsumerState<LoginPage> {
+  bool _acceptedPrivacyPolicy = false;
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Anmelden'),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton.icon(
-              icon: const Icon(Icons.login), // Hier könnte ein Google-Icon stehen
-              label: const Text('Mit Google anmelden'),
-              onPressed: () async {
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Datenschutz-Checkbox
+              CheckboxListTile(
+                value: _acceptedPrivacyPolicy,
+                onChanged: (value) {
+                  setState(() {
+                    _acceptedPrivacyPolicy = value ?? false;
+                  });
+                },
+                controlAffinity: ListTileControlAffinity.leading,
+                title: RichText(
+                  text: TextSpan(
+                    style: Theme.of(context).textTheme.bodyMedium,
+                    children: [
+                      const TextSpan(text: 'Ich akzeptiere die '),
+                      TextSpan(
+                        text: 'Datenschutzerklärung',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                          decoration: TextDecoration.underline,
+                        ),
+                        recognizer: TapGestureRecognizer()
+                          ..onTap = () {
+                            PrivacyPolicyDialog.show(context);
+                          },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                icon: const Icon(Icons.login), // Hier könnte ein Google-Icon stehen
+                label: const Text('Mit Google anmelden'),
+                onPressed: !_acceptedPrivacyPolicy ? null : () async {
                 // Zeige Loading-Dialog
                 if (context.mounted) {
                   showDialog(
@@ -157,18 +198,19 @@ class LoginPage extends ConsumerWidget {
                   }
                 }
               },
-            ),
-            TextButton(
-              child: const Text('Überspringen'),
-              onPressed: () {
-                Navigator.of(context).pushReplacement(
-                  MaterialPageRoute(builder: (context) => HomeScreen(
-                    initialIndex: returnToReports ? 1 : 0,
-                  )),
-                );
-              },
-            ),
-          ],
+              ),
+              TextButton(
+                child: const Text('Überspringen'),
+                onPressed: () {
+                  Navigator.of(context).pushReplacement(
+                    MaterialPageRoute(builder: (context) => HomeScreen(
+                      initialIndex: widget.returnToReports ? 1 : 0,
+                    )),
+                  );
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/presentation/screens/settings_page.dart
+++ b/lib/presentation/screens/settings_page.dart
@@ -15,6 +15,7 @@ import '../widgets/add_adjustment_modal.dart';
 import '../widgets/edit_target_hours_modal.dart';
 import '../widgets/edit_workdays_modal.dart';
 import '../widgets/update_required_dialog.dart';
+import '../widgets/privacy_policy_dialog.dart';
 import 'login_page.dart';
 
 class SettingsPage extends ConsumerWidget {
@@ -155,7 +156,7 @@ class SettingsPage extends ConsumerWidget {
               ListTile(
                 title: const Text('Datenschutz'),
                 trailing: const Icon(Icons.chevron_right),
-                onTap: () {},
+                onTap: () => PrivacyPolicyDialog.show(context),
               ),
               if (authState.asData?.value != null) ...[
                 const Divider(height: 1),

--- a/lib/presentation/widgets/privacy_policy_dialog.dart
+++ b/lib/presentation/widgets/privacy_policy_dialog.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+
+/// Dialog zum Anzeigen der Datenschutzerklärung
+class PrivacyPolicyDialog extends StatelessWidget {
+  const PrivacyPolicyDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      child: Column(
+        children: [
+          AppBar(
+            title: const Text('Datenschutzerklärung'),
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildSection(
+                    'Einleitung',
+                    'Wir nehmen den Schutz Ihrer persönlichen Daten ernst. Diese Datenschutzerklärung informiert Sie über die Verarbeitung personenbezogener Daten bei der Nutzung unserer Work Time Manager App.',
+                  ),
+                  _buildSection(
+                    'Verantwortlicher',
+                    'Verantwortlich für die Datenverarbeitung ist:\n\n[Ihr Name/Ihre Firma]\n[Adresse]\n[E-Mail]\n[Telefonnummer]',
+                  ),
+                  _buildSection(
+                    'Welche Daten werden erhoben?',
+                    'Bei der Nutzung der App werden folgende Daten verarbeitet:\n\n'
+                    '• Arbeitszeiteinträge (Datum, Uhrzeit, Dauer)\n'
+                    '• Überstundensaldo\n'
+                    '• Persönliche Einstellungen (Soll-Arbeitszeit, Arbeitstage)\n'
+                    '• Bei Anmeldung: Google-Kontoinformationen (Name, E-Mail, Profilbild)',
+                  ),
+                  _buildSection(
+                    'Wie werden die Daten verwendet?',
+                    'Die erhobenen Daten werden ausschließlich für folgende Zwecke verwendet:\n\n'
+                    '• Erfassung und Verwaltung Ihrer Arbeitszeiten\n'
+                    '• Berechnung von Überstunden und Berichten\n'
+                    '• Synchronisierung Ihrer Daten über mehrere Geräte (bei Anmeldung)',
+                  ),
+                  _buildSection(
+                    'Speicherung der Daten',
+                    'Lokale Speicherung: Ohne Anmeldung werden alle Daten lokal auf Ihrem Gerät gespeichert.\n\n'
+                    'Cloud-Speicherung: Bei Anmeldung mit Google werden Ihre Daten in Firebase (Google Cloud Platform) gespeichert. Die Datenübertragung erfolgt verschlüsselt.',
+                  ),
+                  _buildSection(
+                    'Weitergabe von Daten',
+                    'Ihre Daten werden nicht an Dritte weitergegeben, verkauft oder vermietet. Eine Weitergabe erfolgt nur:\n\n'
+                    '• Bei gesetzlicher Verpflichtung\n'
+                    '• Mit Ihrer ausdrücklichen Einwilligung',
+                  ),
+                  _buildSection(
+                    'Ihre Rechte',
+                    'Sie haben folgende Rechte bezüglich Ihrer Daten:\n\n'
+                    '• Auskunft über gespeicherte Daten\n'
+                    '• Berichtigung unrichtiger Daten\n'
+                    '• Löschung Ihrer Daten\n'
+                    '• Einschränkung der Verarbeitung\n'
+                    '• Datenübertragbarkeit\n'
+                    '• Widerspruch gegen die Verarbeitung',
+                  ),
+                  _buildSection(
+                    'Account-Löschung',
+                    'Sie können Ihren Account und alle zugehörigen Daten jederzeit in den Einstellungen der App löschen. Diese Aktion ist unwiderruflich.',
+                  ),
+                  _buildSection(
+                    'Änderungen der Datenschutzerklärung',
+                    'Wir behalten uns vor, diese Datenschutzerklärung anzupassen, um sie an geänderte Rechtslage oder bei Änderungen der App anzupassen.',
+                  ),
+                  _buildSection(
+                    'Kontakt',
+                    'Bei Fragen zum Datenschutz kontaktieren Sie uns bitte unter:\n\n[Ihre E-Mail-Adresse]',
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Stand: ${DateTime.now().year}-${DateTime.now().month.toString().padLeft(2, '0')}',
+                    style: const TextStyle(
+                      fontStyle: FontStyle.italic,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSection(String title, String content) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 16),
+        Text(
+          title,
+          style: const TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          content,
+          style: const TextStyle(fontSize: 14, height: 1.5),
+        ),
+      ],
+    );
+  }
+
+  /// Zeigt den Datenschutz-Dialog an
+  static void show(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => const PrivacyPolicyDialog(),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.6.7
+version: 0.7.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
### Description

This pull request adds a Privacy Policy dialog and integrates it into the app's settings and login pages:

- Introduced a `PrivacyPolicyDialog` widget to display the privacy policy.
- Enabled showing the dialog from the settings page.
- Made it mandatory for users to accept the privacy policy before logging in.
- Updated the app version to 0.7.0 in `pubspec.yaml`.

close #17