### PR TITLE
Add estimated end-of-work display to dashboard

### DIFF
--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -84,6 +84,8 @@ class DashboardScreen extends ConsumerWidget {
             _buildOvertime(context, liveTotalOvertime, 'Überstunden Gesamt'),
             const SizedBox(height: 16),
             _buildOvertime(context, dashboardState.dailyOvertime, 'Heutige Überstunden'),
+            _buildExpectedEndTime(context, dashboardState.expectedEndTime),
+            _buildExpectedEndTimeWithBalance(context, dashboardState.expectedEndTime, dashboardState.overtime),
             const SizedBox(height: 24),
 
             _TimeInputField(
@@ -146,6 +148,49 @@ class DashboardScreen extends ConsumerWidget {
           style: Theme.of(context).textTheme.headlineMedium?.copyWith(color: overtimeColor),
         ),
       ],
+    );
+  }
+
+  Widget _buildExpectedEndTime(BuildContext context, DateTime? expectedEndTime) {
+    if (expectedEndTime == null) {
+      return const SizedBox.shrink();
+    }
+
+    final formattedTime = DateFormat.Hm().format(expectedEndTime);
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0),
+      child: Text(
+        'Voraussichtlicher Feierabend (±0): $formattedTime Uhr',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Colors.grey[600],
+          fontStyle: FontStyle.italic,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+
+  Widget _buildExpectedEndTimeWithBalance(BuildContext context, DateTime? expectedEndTime, Duration? overtime) {
+    if (expectedEndTime == null || overtime == null) {
+      return const SizedBox.shrink();
+    }
+
+    // Berechne Feierabend-Zeit, um die Gleitzeit-Bilanz auf 0 zu bringen
+    final expectedEndTimeWithBalance = expectedEndTime.subtract(overtime);
+    final formattedTimeWithBalance = DateFormat.Hm().format(expectedEndTimeWithBalance);
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 2.0),
+      child: Text(
+        'Mit Gleitzeit-Bilanz auf 0: $formattedTimeWithBalance Uhr',
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: Colors.grey[500],
+          fontStyle: FontStyle.italic,
+          fontSize: 11,
+        ),
+        textAlign: TextAlign.center,
+      ),
     );
   }
 

--- a/lib/presentation/state/dashboard_state.dart
+++ b/lib/presentation/state/dashboard_state.dart
@@ -9,6 +9,7 @@ class DashboardState extends Equatable {
   final bool isLoading;
   final Duration? overtime;
   final Duration? dailyOvertime;
+  final DateTime? expectedEndTime; // Voraussichtliche Feierabendzeit für ±0
 
   const DashboardState({
     required this.workEntry,
@@ -17,6 +18,7 @@ class DashboardState extends Equatable {
     this.isLoading = false,
     this.overtime,
     this.dailyOvertime,
+    this.expectedEndTime,
   });
 
   factory DashboardState.initial() {
@@ -30,6 +32,7 @@ class DashboardState extends Equatable {
       isLoading: true, // Start with loading
       overtime: null,
       dailyOvertime: null,
+      expectedEndTime: null,
     );
   }
 
@@ -40,6 +43,7 @@ class DashboardState extends Equatable {
     bool? isLoading,
     Duration? overtime,
     Duration? dailyOvertime,
+    DateTime? expectedEndTime,
   }) {
     return DashboardState(
       workEntry: workEntry ?? this.workEntry,
@@ -48,6 +52,7 @@ class DashboardState extends Equatable {
       isLoading: isLoading ?? this.isLoading,
       overtime: overtime ?? this.overtime,
       dailyOvertime: dailyOvertime ?? this.dailyOvertime,
+      expectedEndTime: expectedEndTime ?? this.expectedEndTime,
     );
   }
 
@@ -59,5 +64,6 @@ class DashboardState extends Equatable {
         isLoading,
         overtime,
         dailyOvertime,
+        expectedEndTime,
       ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.8.0
+version: 0.9.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Added an estimated end-of-work feature to the dashboard for users to see:  
- When to stop working to avoid extra hours today.  
- The time to achieve a zero balance for cumulative flex time.  

**Key updates:**
- Calculations based on start time, required hours, and breaks taken.  
- Automatic updates every second during active time tracking.  
- Displayed in small, gray text under "Today's overtime" for clarity.  
- Incremented app version to 0.9.0.

close #67