### PR TITLE
feat: Add work entry types and quick entry dialog

### DIFF
--- a/lib/data/models/work_entry_model.dart
+++ b/lib/data/models/work_entry_model.dart
@@ -16,6 +16,7 @@ class WorkEntryModel extends WorkEntryEntity {
     super.manualOvertime,
     super.description,
     super.isManuallyEntered,
+    super.type,
   });
 
   static String generateId(DateTime date) => DateFormat('yyyy-MM-dd').format(date);
@@ -40,6 +41,7 @@ class WorkEntryModel extends WorkEntryEntity {
       breaks: entity.breaks.map((e) => BreakModel.fromEntity(e)).toList(),
       description: entity.description,
       isManuallyEntered: entity.isManuallyEntered,
+      type: entity.type,
     );
   }
 
@@ -58,6 +60,12 @@ class WorkEntryModel extends WorkEntryEntity {
           : null,
       description: map['description'] as String?,
       isManuallyEntered: map['isManuallyEntered'] as bool? ?? false,
+      type: map['type'] != null
+          ? WorkEntryType.values.firstWhere(
+              (e) => e.name == map['type'],
+              orElse: () => WorkEntryType.work,
+            )
+          : WorkEntryType.work,
     );
   }
 
@@ -78,6 +86,7 @@ class WorkEntryModel extends WorkEntryEntity {
       'manualOvertimeMinutes': manualOvertime?.inMinutes,
       'description': description,
       'isManuallyEntered': isManuallyEntered,
+      'type': type.name,
     };
   }
 
@@ -95,6 +104,7 @@ class WorkEntryModel extends WorkEntryEntity {
     Duration? manualOvertime,
     String? description,
     bool? isManuallyEntered,
+    WorkEntryType? type,
   }) {
     return WorkEntryModel(
       id: id ?? this.id,
@@ -105,6 +115,7 @@ class WorkEntryModel extends WorkEntryEntity {
       manualOvertime: manualOvertime ?? this.manualOvertime,
       description: description ?? this.description,
       isManuallyEntered: isManuallyEntered ?? this.isManuallyEntered,
+      type: type ?? this.type,
     );
   }
 }

--- a/lib/domain/entities/work_entry_entity.dart
+++ b/lib/domain/entities/work_entry_entity.dart
@@ -2,6 +2,13 @@ import 'package:equatable/equatable.dart';
 
 import 'break_entity.dart';
 
+enum WorkEntryType {
+  work,
+  vacation,
+  sick,
+  holiday,
+}
+
 /// Die WorkEntryEntity ist ein reines Datenobjekt der Domain-Schicht.
 /// Sie repräsentiert alle Informationen für einen einzelnen Arbeitstag.
 class WorkEntryEntity extends Equatable {
@@ -13,6 +20,7 @@ class WorkEntryEntity extends Equatable {
   final Duration? manualOvertime;
   final bool isManuallyEntered;
   final String? description; // Added
+  final WorkEntryType type;
 
   const WorkEntryEntity({
     required this.id,
@@ -23,6 +31,7 @@ class WorkEntryEntity extends Equatable {
     this.manualOvertime,
     this.isManuallyEntered = false,
     this.description, // Added
+    this.type = WorkEntryType.work,
   });
 
   /// Die gesamte Pausenzeit für diesen Arbeitseintrag.
@@ -59,6 +68,7 @@ class WorkEntryEntity extends Equatable {
     Duration? manualOvertime,
     bool? isManuallyEntered,
     String? description, // Added
+    WorkEntryType? type,
   }) {
     return WorkEntryEntity(
       id: id ?? this.id,
@@ -69,6 +79,7 @@ class WorkEntryEntity extends Equatable {
       manualOvertime: manualOvertime ?? this.manualOvertime,
       isManuallyEntered: isManuallyEntered ?? this.isManuallyEntered,
       description: description ?? this.description, // Added
+      type: type ?? this.type,
     );
   }
 
@@ -82,5 +93,6 @@ class WorkEntryEntity extends Equatable {
         manualOvertime,
         isManuallyEntered,
         description, // Added
+        type,
       ];
 }

--- a/lib/domain/entities/work_entry_extensions.dart
+++ b/lib/domain/entities/work_entry_extensions.dart
@@ -31,6 +31,12 @@ extension WorkEntryCalculations on WorkEntryEntity {
   ///
   /// [targetDailyHours] Die tägliche Soll-Arbeitszeit.
   Duration calculateOvertime(Duration targetDailyHours) {
+    // Bei Sonder-Einträgen (Urlaub, Krank, Feiertag) gilt die Sollzeit als erfüllt.
+    // Die Überstunden sind daher 0, es sei denn, es wurden manuelle Korrekturen vorgenommen.
+    if (type == WorkEntryType.vacation || type == WorkEntryType.sick || type == WorkEntryType.holiday) {
+      return manualOvertime ?? Duration.zero;
+    }
+
     // Überstunden können erst berechnet werden, wenn der Arbeitstag abgeschlossen ist.
     if (workEnd == null) return Duration.zero;
 

--- a/lib/presentation/state/edit_work_entry_state.dart
+++ b/lib/presentation/state/edit_work_entry_state.dart
@@ -8,12 +8,14 @@ class EditWorkEntryState extends Equatable {
   final DateTime? newStartTime;
   final DateTime? newEndTime;
   final List<BreakEntity> breaks;
+  final WorkEntryType type;
 
   const EditWorkEntryState({
     required this.originalEntry,
     this.newStartTime,
     this.newEndTime,
     required this.breaks,
+    required this.type,
   });
 
   factory EditWorkEntryState.fromWorkEntry(WorkEntryEntity entry) {
@@ -22,6 +24,7 @@ class EditWorkEntryState extends Equatable {
       newStartTime: entry.workStart,
       newEndTime: entry.workEnd,
       breaks: entry.breaks,
+      type: entry.type,
     );
   }
 
@@ -29,15 +32,17 @@ class EditWorkEntryState extends Equatable {
     DateTime? newStartTime,
     DateTime? newEndTime,
     List<BreakEntity>? breaks,
+    WorkEntryType? type,
   }) {
     return EditWorkEntryState(
       originalEntry: originalEntry,
       newStartTime: newStartTime ?? this.newStartTime,
       newEndTime: newEndTime ?? this.newEndTime,
       breaks: breaks ?? this.breaks,
+      type: type ?? this.type,
     );
   }
 
   @override
-  List<Object?> get props => [originalEntry, newStartTime, newEndTime, breaks];
+  List<Object?> get props => [originalEntry, newStartTime, newEndTime, breaks, type];
 }

--- a/lib/presentation/view_models/edit_work_entry_view_model.dart
+++ b/lib/presentation/view_models/edit_work_entry_view_model.dart
@@ -19,6 +19,10 @@ class EditWorkEntryViewModel extends StateNotifier<EditWorkEntryState> {
   EditWorkEntryViewModel(WorkEntryEntity entry, this._ref)
       : super(EditWorkEntryState.fromWorkEntry(entry));
 
+  void setType(WorkEntryType type) {
+    state = state.copyWith(type: type);
+  }
+
   void setStartTime(DateTime startTime) {
     state = state.copyWith(newStartTime: startTime);
   }
@@ -65,12 +69,18 @@ class EditWorkEntryViewModel extends StateNotifier<EditWorkEntryState> {
   }
 
   Future<void> saveChanges() async {
-    if (state.newStartTime == null) return;
+    // Wenn Typ 'work' ist, MUSS eine Startzeit existieren.
+    if (state.type == WorkEntryType.work && state.newStartTime == null) return;
+
+    final isStandardWork = state.type == WorkEntryType.work;
 
     final updatedEntry = state.originalEntry.copyWith(
-      workStart: state.newStartTime,
-      workEnd: state.newEndTime,
-      breaks: state.breaks,
+      workStart: isStandardWork ? state.newStartTime : null,
+      workEnd: isStandardWork ? state.newEndTime : null,
+      breaks: isStandardWork ? state.breaks : [],
+      type: state.type,
+      // ManuallyEntered ist true, wenn wir hier speichern.
+      isManuallyEntered: true,
     );
     await _ref.read(reportsViewModelProvider.notifier).saveWorkEntry(updatedEntry);
   }

--- a/lib/presentation/widgets/edit_work_entry_modal.dart
+++ b/lib/presentation/widgets/edit_work_entry_modal.dart
@@ -34,17 +34,44 @@ class EditWorkEntryModal extends ConsumerWidget {
                 'Eintrag für den ${DateFormat.yMd('de_DE').format(workEntry.date)} bearbeiten',
                 style: Theme.of(context).textTheme.titleLarge,
               ),
-              const SizedBox(height: 24),
-              Expanded(
-                child: ListView(
-                  controller: controller,
-                  children: [
-                    _buildTimeSection(context, state, viewModel),
-                    const SizedBox(height: 24),
-                    _buildBreaksSection(context, state, viewModel),
-                  ],
+              const SizedBox(height: 16),
+              DropdownButtonFormField<WorkEntryType>(
+                value: state.type,
+                decoration: const InputDecoration(
+                  labelText: 'Typ',
+                  border: OutlineInputBorder(),
                 ),
+                items: const [
+                  DropdownMenuItem(value: WorkEntryType.work, child: Text('Arbeit')),
+                  DropdownMenuItem(value: WorkEntryType.vacation, child: Text('Urlaub')),
+                  DropdownMenuItem(value: WorkEntryType.sick, child: Text('Krankheit')),
+                  DropdownMenuItem(value: WorkEntryType.holiday, child: Text('Feiertag')),
+                ],
+                onChanged: (val) {
+                  if (val != null) viewModel.setType(val);
+                },
               ),
+              const SizedBox(height: 24),
+              if (state.type == WorkEntryType.work) ...[
+                Expanded(
+                  child: ListView(
+                    controller: controller,
+                    children: [
+                      _buildTimeSection(context, state, viewModel),
+                      const SizedBox(height: 24),
+                      _buildBreaksSection(context, state, viewModel),
+                    ],
+                  ),
+                ),
+              ] else
+                const Expanded(
+                  child: Center(
+                    child: Text(
+                      'Ganztägiges Ereignis.\nKeine detaillierte Zeiterfassung notwendig.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
               const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: () async {

--- a/lib/presentation/widgets/quick_entry_dialog.dart
+++ b/lib/presentation/widgets/quick_entry_dialog.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../domain/entities/work_entry_entity.dart';
+
+class QuickEntryDialog extends StatefulWidget {
+  final DateTime date;
+  final Duration? dailyTarget;
+
+  const QuickEntryDialog({super.key, required this.date, this.dailyTarget});
+
+  @override
+  State<QuickEntryDialog> createState() => _QuickEntryDialogState();
+}
+
+class _QuickEntryDialogState extends State<QuickEntryDialog> {
+  WorkEntryType _selectedType = WorkEntryType.vacation;
+  TimeOfDay? _startTime;
+  TimeOfDay? _endTime;
+
+  @override
+  void initState() {
+    super.initState();
+    _setTimesBasedOnTarget();
+  }
+
+  void _setTimesBasedOnTarget() {
+    setState(() {
+      _startTime = const TimeOfDay(hour: 8, minute: 0);
+      if (widget.dailyTarget != null) {
+        final startDateTime = DateTime(2000, 1, 1, 8, 0);
+        final endDateTime = startDateTime.add(widget.dailyTarget!);
+        _endTime = TimeOfDay.fromDateTime(endDateTime);
+      } else {
+        _endTime = const TimeOfDay(hour: 16, minute: 0);
+      }
+    });
+  }
+
+  String _getWorkEntryTypeLabel(WorkEntryType type) {
+    switch (type) {
+      case WorkEntryType.vacation:
+        return '🏖️ Urlaub';
+      case WorkEntryType.sick:
+        return '🤒 Krankheit';
+      case WorkEntryType.holiday:
+        return '📅 Feiertag';
+      case WorkEntryType.work:
+        return '💼 Arbeit';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('Schnell-Eintrag'),
+          const SizedBox(height: 4),
+          Text(
+            DateFormat.yMMMMd('de_DE').format(widget.date),
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          DropdownButtonFormField<WorkEntryType>(
+            value: _selectedType,
+            decoration: const InputDecoration(labelText: 'Typ'),
+            items: [
+              WorkEntryType.vacation,
+              WorkEntryType.sick,
+              WorkEntryType.holiday,
+            ].map((type) {
+              return DropdownMenuItem(
+                value: type,
+                child: Text(_getWorkEntryTypeLabel(type)),
+              );
+            }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                setState(() {
+                  _selectedType = value;
+                });
+                _setTimesBasedOnTarget();
+              }
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Abbrechen'),
+        ),
+        FilledButton(
+          onPressed: () {
+             // Create the entry
+             final entry = WorkEntryEntity(
+               id: DateFormat('yyyy-MM-dd').format(widget.date),
+               date: widget.date,
+               type: _selectedType,
+               isManuallyEntered: true,
+               workStart: _startTime != null 
+                   ? DateTime(widget.date.year, widget.date.month, widget.date.day, _startTime!.hour, _startTime!.minute)
+                   : null,
+               workEnd: _endTime != null
+                   ? DateTime(widget.date.year, widget.date.month, widget.date.day, _endTime!.hour, _endTime!.minute)
+                   : null,
+             );
+             Navigator.pop(context, entry);
+          },
+          child: const Text('Speichern'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Description
This PR improves the "Quick Entry" functionality in the daily reports by introducing a dedicated dialog that automates time tracking for special entry types like vacation, sickness, or holidays.

Previously, quick entries did not include specific start and end times. With this update, these times are automatically calculated based on the user's daily target hours, ensuring accurate overtime calculation and consistent
reporting.

Key Changes
- New `QuickEntryDialog`:
    - Replaced the simple dialog with a custom widget that handles entry type selection and time calculation.
    - Automated Time Filling: When a type is selected, the start time is set to 08:00, and the end time is automatically calculated using the user's daily target hours (Soll-Stunden).
    - UI Polish: Added emojis (🏖️, 🤒, 📅) to the dropdown menu for a more visually appealing experience.
- Enhanced Report Visibility:
    - Updated DailyReportView and DayEntriesBottomSheet to display start and end times for special types (Vacation, Sick, Holiday) if they are present.
- Improved Workflow:
    - Streamlined the process: Users now only need to select the type and click "Save", with all necessary data being generated in the background.

close #77