### PR TITLE
feat: Improve dashboard time tracking and allow clearing end time

### DIFF
--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -47,6 +47,16 @@ class DashboardScreen extends ConsumerWidget {
     final dailyOvertime = dashboardState.dailyOvertime ?? Duration.zero;
     final liveTotalOvertime = baseOvertime + dailyOvertime;
 
+    final netDuration = dashboardState.actualWorkDuration ?? dashboardState.elapsedTime;
+    
+    // Berechne Pausendauer für Brutto-Anzeige
+    final totalBreakDuration = workEntryWithAutoBreaks.breaks.fold(Duration.zero, (prev, b) {
+      final end = b.end ?? DateTime.now();
+      return prev + end.difference(b.start);
+    });
+
+    final grossDuration = netDuration + totalBreakDuration;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Arbeitszeit'),
@@ -68,17 +78,16 @@ class DashboardScreen extends ConsumerWidget {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Text(
-              _formatDuration(dashboardState.elapsedTime),
+              _formatDuration(netDuration),
               style: Theme.of(context).textTheme.displayLarge,
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
-            if (dashboardState.actualWorkDuration != null)
-              Text(
-                'Gearbeitete Zeit: ${_formatDuration(dashboardState.actualWorkDuration!)}',
-                style: Theme.of(context).textTheme.titleMedium,
-                textAlign: TextAlign.center,
-              ),
+            Text(
+              'Anwesenheit (Brutto): ${_formatDuration(grossDuration)}',
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
             const SizedBox(height: 24),
 
             _buildOvertime(context, liveTotalOvertime, 'Überstunden Gesamt'),
@@ -99,6 +108,7 @@ class DashboardScreen extends ConsumerWidget {
               initialValue: workEntry.workEnd,
               enabled: workEntry.workStart != null,
               onTimeSelected: (time) => dashboardViewModel.setManualEndTime(time),
+              onClear: workEntry.workEnd != null ? () => dashboardViewModel.clearEndTime() : null,
             ),
             const SizedBox(height: 24),
 
@@ -122,7 +132,6 @@ class DashboardScreen extends ConsumerWidget {
                       : 'Pause hinzufügen'),
             ),
             const SizedBox(height: 24),
-            _buildActualWorkDuration(context, dashboardState.actualWorkDuration),
           ],
         ),
       ),
@@ -194,26 +203,6 @@ class DashboardScreen extends ConsumerWidget {
     );
   }
 
-  Widget _buildActualWorkDuration(BuildContext context, Duration? actualWorkDuration) {
-    if (actualWorkDuration == null) {
-      return const SizedBox.shrink();
-    }
-    final formattedDuration = _formatDuration(actualWorkDuration);
-    return Column(
-      children: [
-        Text(
-          'Gearbeitete Stunden',
-          style: Theme.of(context).textTheme.titleMedium,
-        ),
-        const SizedBox(height: 4),
-        Text(
-          formattedDuration,
-          style: Theme.of(context).textTheme.headlineMedium,
-        ),
-      ],
-    );
-  }
-
   Widget _buildBreaksSection(
       BuildContext context, WidgetRef ref, List<BreakEntity> breaks) {
     final dashboardViewModel = ref.read(dashboardViewModelProvider.notifier);
@@ -282,12 +271,14 @@ class _TimeInputField extends StatefulWidget {
   final String label;
   final DateTime? initialValue;
   final ValueChanged<TimeOfDay>? onTimeSelected;
+  final VoidCallback? onClear;
   final bool enabled;
 
   const _TimeInputField({
     required this.label,
     this.initialValue,
     this.onTimeSelected,
+    this.onClear,
     this.enabled = true,
   });
 
@@ -353,7 +344,13 @@ class _TimeInputFieldState extends State<_TimeInputField> {
       decoration: InputDecoration(
         labelText: widget.label,
         border: const OutlineInputBorder(),
-        suffixIcon: widget.enabled ? const Icon(Icons.access_time) : null,
+        suffixIcon: widget.initialValue != null && widget.onClear != null
+            ? IconButton(
+                icon: const Icon(Icons.clear),
+                onPressed: widget.onClear,
+                tooltip: '${widget.label} entfernen',
+              )
+            : (widget.enabled ? const Icon(Icons.access_time) : null),
       ),
       onTap: _selectTime,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.11.2
+version: 0.13.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Overview
This Pull Request focuses on improving the flexibility and clarity of time tracking within the Dashboard. It enables users to correct accidental inputs and provides a more comprehensive view of their daily work status.

Key Changes

1. Resume Timer by Clearing End Time
- Feature: Added the ability to remove an accidentally entered end time, effectively resuming the workday.
- UI: Introduced a "clear" (X) button in the End Time input field on the Dashboard.
- Logic: Implemented clearEndTime in the DashboardViewModel. Removing the end time reverts the work entry status to "running," allowing the live timer to continue seamlessly.
- Bug Fix: Enhanced _startTimerIfNeeded to ensure the UI updates immediately upon timer restart, preventing any display lag.

2. Dual Time Display (Net vs. Gross)
- UI Enhancement: The Dashboard now clearly differentiates between working and attendance hours:
    - Primary Timer (Net): Prominently displays actual working hours (excluding breaks).
    - Secondary Label (Gross): Added a "Anwesenheit (Brutto)" line below the main timer, showing the total time elapsed since the start of work, including breaks.

Technical Details
- Modified DashboardViewModel to handle state transitions between "Finished" and "Running" entries cleanly.
- Updated DashboardScreen logic to dynamically calculate and display gross duration based on the current state.

close #78