### PR TITLE
fix: Correct expected end time calculation and bump version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.13.0
+version: 0.13.1
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Overview
This PR fixes a bug in the calculation of the "Expected End Time" (Feierabend ±0) on the Dashboard. Previously, the calculation did not account for mandatory or future automatic breaks, resulting in a predicted leave time
that was too early for users to actually reach their daily net target.

Problem
The previous implementation used a simple formula: Start Time + Target Hours + Existing Breaks.
However, it ignored the fact that according to labor laws (and the app's BreakCalculatorService), working more than 6 or 9 hours triggers additional mandatory break deductions.

Example: A user starting at 08:00 with an 8h target was told they could leave at 16:00. But leaving at 16:00 with a mandatory 30m deduction results in only 7.5h of net work time, leaving the user with a negative balance.

Key Changes
- Iterative Break Prediction: Updated _calculateExpectedEndTime in DashboardViewModel to predict the required break time based on the projected gross duration.
- Dynamic Threshold Handling: The logic now accounts for "tier jumps" (e.g., if adding a 30m break pushes the total attendance over 9 hours, it automatically adjusts to the required 45m break).
- Statutory Alignment: Uses the constants from BreakCalculatorService (6h/30m and 9h/45m rules) to ensure the prediction matches the final deduction applied when the timer stops.
