### PR TITLE
feat: Responsive UI overhaul and Google Auth fixes

### DIFF
--- a/lib/data/datasources/remote/firestore_datasource.dart
+++ b/lib/data/datasources/remote/firestore_datasource.dart
@@ -38,6 +38,9 @@ class FirestoreDataSourceImpl implements FirestoreDataSource {
         await _firebaseAuth.signInWithPopup(firebase.GoogleAuthProvider());
       } else {
         // Auf Mobile: Verwende google_sign_in mit authenticate()
+        // WICHTIG: initialize() muss vor authenticate() aufgerufen werden (seit google_sign_in 7.0)
+        await _googleSignIn.initialize();
+        
         final GoogleSignInAccount? googleUser = await _googleSignIn.authenticate(
           scopeHint: ['email', 'profile'],
         );
@@ -68,7 +71,10 @@ class FirestoreDataSourceImpl implements FirestoreDataSource {
 
   @override
   Future<void> signOut() async {
-    await Future.wait([_firebaseAuth.signOut(), _googleSignIn.signOut()]);
+    await _firebaseAuth.signOut();
+    if (!kIsWeb) {
+      await _googleSignIn.signOut();
+    }
   }
 
   @override
@@ -87,6 +93,8 @@ class FirestoreDataSourceImpl implements FirestoreDataSource {
           await userCredential.user?.delete();
         } else {
           // Auf Mobile: authenticate()
+          await _googleSignIn.initialize();
+          
           final GoogleSignInAccount? googleUser = await _googleSignIn.authenticate(
             scopeHint: ['email', 'profile'],
           );

--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -7,7 +7,6 @@ import '../../domain/services/break_calculator_service.dart';
 import '../view_models/dashboard_view_model.dart';
 import '../widgets/common/responsive_center.dart';
 import '../widgets/edit_break_modal.dart';
-import 'settings_page.dart';
 
 class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
@@ -56,22 +55,13 @@ class DashboardScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Arbeitszeit'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.settings),
-            onPressed: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(builder: (context) => const SettingsPage()),
-              );
-            },
-          ),
-        ],
       ),
-      body: ResponsiveCenter(
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          final isWide = constraints.maxWidth > 900;
+          final double contentWidth = isWide ? 1200.0 : 800.0;
+
+          final timerDisplay = Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
               Text(
@@ -85,15 +75,23 @@ class DashboardScreen extends ConsumerWidget {
                 style: Theme.of(context).textTheme.titleMedium,
                 textAlign: TextAlign.center,
               ),
-              const SizedBox(height: 24),
+            ],
+          );
 
+          final overtimeStats = Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
               _buildOvertime(context, totalOvertime, 'Überstunden Gesamt'),
               const SizedBox(height: 16),
               _buildOvertime(context, dashboardState.dailyOvertime, 'Heutige Überstunden'),
               _buildExpectedEndTime(context, dashboardState.expectedEndTime),
               _buildExpectedEndTimeWithBalance(context, dashboardState.expectedEndTotalZero),
-              const SizedBox(height: 24),
+            ],
+          );
 
+          final timerControls = Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
               _TimeInputField(
                 label: 'Startzeit',
                 initialValue: workEntry.workStart,
@@ -108,7 +106,6 @@ class DashboardScreen extends ConsumerWidget {
                 onClear: workEntry.workEnd != null ? () => dashboardViewModel.clearEndTime() : null,
               ),
               const SizedBox(height: 24),
-
               ElevatedButton(
                 onPressed: () => dashboardViewModel.startOrStopTimer(),
                 style: ElevatedButton.styleFrom(
@@ -118,8 +115,12 @@ class DashboardScreen extends ConsumerWidget {
                     ? 'Zeiterfassung beenden'
                     : 'Zeiterfassung starten'),
               ),
-              const SizedBox(height: 24),
+            ],
+          );
 
+          final breaksSection = Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
               _buildBreaksSection(context, ref, workEntryWithAutoBreaks.breaks),
               const SizedBox(height: 16),
               ElevatedButton(
@@ -128,10 +129,56 @@ class DashboardScreen extends ConsumerWidget {
                         ? 'Pause beenden'
                         : 'Pause hinzufügen'),
               ),
-              const SizedBox(height: 24),
             ],
-          ),
-        ),
+          );
+
+          return ResponsiveCenter(
+            maxContentWidth: contentWidth,
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(16.0),
+              child: isWide
+                  ? Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              timerDisplay,
+                              const SizedBox(height: 32),
+                              overtimeStats,
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 32),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              timerControls,
+                              const SizedBox(height: 32),
+                              breaksSection,
+                            ],
+                          ),
+                        ),
+                      ],
+                    )
+                  : Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        timerDisplay,
+                        const SizedBox(height: 24),
+                        overtimeStats,
+                        const SizedBox(height: 24),
+                        timerControls,
+                        const SizedBox(height: 24),
+                        breaksSection,
+                        const SizedBox(height: 24),
+                      ],
+                    ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/presentation/screens/settings_page.dart
+++ b/lib/presentation/screens/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/providers/providers.dart' as core_providers;
 import '../../data/repositories/hybrid_work_repository_impl.dart';
@@ -29,7 +30,6 @@ class SettingsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final settingsValue = ref.watch(settingsViewModelProvider);
-    final themeMode = ref.watch(themeViewModelProvider);
     final themeNotifier = ref.read(themeViewModelProvider.notifier);
     final authState = ref.watch(authStateProvider);
 
@@ -42,158 +42,225 @@ class SettingsPage extends ConsumerWidget {
         error: (err, stack) => Center(child: Text('Fehler: $err')),
         data: (settingsState) {
           final settings = settingsState.settings;
-          return ResponsiveCenter(
-            child: ListView(
-              children: [
-                const SizedBox(height: 16),
-                _buildProfileSection(context, ref),
-                const SizedBox(height: 8),
-                _buildAuthButton(context, ref),
-                const SizedBox(height: 8),
-                const SizedBox(height: 16),
-                const Divider(height: 1),
-                ListTile(
-                  title: const Text('Soll-Arbeitsstunden'),
-                  subtitle: Text(
-                    '${settings.weeklyTargetHours.toStringAsFixed(1)} h/Woche',
-                  ),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    showEditTargetHoursModal(
-                      context,
-                      settings.weeklyTargetHours,
-                    );
-                  },
-                ),
-                ListTile(
-                  title: const Text('Arbeitstage pro Woche'),
-                  subtitle: Text(
-                    '${settings.workdaysPerWeek} Tage',
-                  ),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    showEditWorkdaysModal(
-                      context,
-                      settings.workdaysPerWeek,
-                    );
-                  },
-                ),
-                ListTile(
-                  title: const Text('Tägliche Soll-Arbeitszeit'),
-                  subtitle: Text(
-                    '≈ ${settings.workdaysPerWeek > 0 ? (settings.weeklyTargetHours / settings.workdaysPerWeek).toStringAsFixed(1) : '0.0'} h/Tag',
-                  ),
-                ),
-                const Divider(height: 1),
-                const SizedBox(height: 16),
-                _buildOvertimeBalance(context, settingsState.overtimeBalance),
-                const SizedBox(height: 16),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: ElevatedButton(
-                    onPressed: () {
-                      showDialog(
-                        context: context,
-                        builder: (context) => const AddAdjustmentModal(),
-                      );
-                    },
-                    child: const Text('Überstunden / Minusstunden anpassen'),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                _buildDataSyncSection(context, ref, authState),
-                const SizedBox(height: 16),
-                const Divider(height: 1),
-                SwitchListTile(
-                  title: const Text('Design'),
-                  subtitle: Text(themeMode == ThemeMode.dark ? 'Dunkel' : 'Hell'),
-                  value: themeMode == ThemeMode.dark,
-                  onChanged: (isDark) {
-                    themeNotifier.setTheme(isDark ? ThemeMode.dark : ThemeMode.light);
-                  },
-                ),
-                const Divider(height: 1),
-                ListTile(
-                  title: const Text('Benachrichtigungen'),
-                  subtitle: settingsState.settings.notificationsEnabled
-                      ? Text('Aktiviert um ${settingsState.settings.notificationTime} Uhr')
-                      : const Text('Deaktiviert'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () {
-                    NotificationSettingsDialog.show(context, settingsState.settings);
-                  },
-                ),
-                const Divider(height: 1),
-                FutureBuilder<PackageInfo>(
-                  future: PackageInfo.fromPlatform(),
-                  builder: (context, snapshot) {
-                    final version = snapshot.data?.version ?? '...';
-                    return ListTile(
-                      title: const Text('Version'),
-                      trailing: Text(version),
-                    );
-                  },
-                ),
-                // DEBUG: Test-Button für Version-Check (nur im Debug-Modus)
-                if (kDebugMode)
-                  ListTile(
-                    leading: const Icon(Icons.bug_report, color: Colors.orange),
-                    title: const Text('🧪 TEST: Version Check'),
-                    subtitle: const Text('Update-Dialog manuell anzeigen'),
-                    onTap: () async {
-                      final versionService = ref.read(core_providers.versionServiceProvider);
-                      await UpdateRequiredDialog.checkAndShow(context, versionService);
-                    },
-                  ),
-                ListTile(
-                  title: const Text('Impressum'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => ImprintDialog.show(context),
-                ),
-                ListTile(
-                  title: const Text('AGB'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => TermsOfServiceDialog.show(context),
-                ),
-                ListTile(
-                  title: const Text('Datenschutz'),
-                  trailing: const Icon(Icons.chevron_right),
-                  onTap: () => PrivacyPolicyDialog.show(context),
-                ),
-                if (authState.asData?.value != null) ...[
-                  const Divider(height: 1),
-                  ListTile(
-                    leading: Icon(Icons.delete_forever, color: theme.colorScheme.error),
-                    title: Text('Account löschen', style: TextStyle(color: theme.colorScheme.error)),
-                    onTap: () {
-                      showDialog(
-                        context: context,
-                        builder: (dialogContext) => AlertDialog(
-                          title: const Text('Account endgültig löschen'),
-                          content: const Text(
-                              'Warnung: Diese Aktion kann nicht rückgängig gemacht werden. Alle Ihre Daten, einschließlich der Arbeitszeiterfassung, werden dauerhaft gelöscht.'),
-                          actions: [
-                            TextButton(
-                              onPressed: () => Navigator.of(dialogContext).pop(),
-                              child: const Text('Abbrechen'),
-                            ),
-                            FilledButton(
-                              onPressed: () {
-                                Navigator.of(dialogContext).pop();
-                                ref.read(deleteAccountProvider)();
-                              },
-                              style: FilledButton.styleFrom(
-                                backgroundColor: theme.colorScheme.error,
-                              ),
-                              child: const Text('Endgültig löschen'),
-                            ),
-                          ],
+
+          final topSection = [
+            const SizedBox(height: 16),
+            _buildProfileSection(context, ref),
+            const SizedBox(height: 8),
+            _buildAuthButton(context, ref),
+            const SizedBox(height: 8),
+            const SizedBox(height: 16),
+          ];
+
+          final leftColumnChildren = [
+            ...topSection,
+            const Divider(height: 1),
+            ListTile(
+              title: const Text('Soll-Arbeitsstunden'),
+              subtitle: Text(
+                '${settings.weeklyTargetHours.toStringAsFixed(1)} h/Woche',
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                showEditTargetHoursModal(
+                  context,
+                  settings.weeklyTargetHours,
+                );
+              },
+            ),
+            ListTile(
+              title: const Text('Arbeitstage pro Woche'),
+              subtitle: Text(
+                '${settings.workdaysPerWeek} Tage',
+              ),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                showEditWorkdaysModal(
+                  context,
+                  settings.workdaysPerWeek,
+                );
+              },
+            ),
+            ListTile(
+              title: const Text('Tägliche Soll-Arbeitszeit'),
+              subtitle: Text(
+                '≈ ${settings.workdaysPerWeek > 0 ? (settings.weeklyTargetHours / settings.workdaysPerWeek).toStringAsFixed(1) : '0.0'} h/Tag',
+              ),
+            ),
+            const Divider(height: 1),
+            const SizedBox(height: 16),
+            _buildOvertimeBalance(context, settingsState.overtimeBalance),
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ElevatedButton(
+                onPressed: () {
+                  showDialog(
+                    context: context,
+                    builder: (context) => const AddAdjustmentModal(),
+                  );
+                },
+                child: const Text('Überstunden / Minusstunden anpassen'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildDataSyncSection(context, ref, authState),
+            const SizedBox(height: 16),
+          ];
+
+          final rightColumnChildren = [
+            const Divider(height: 1),
+            SwitchListTile(
+              title: const Text('Design'),
+              subtitle: Text(Theme.of(context).brightness == Brightness.dark ? 'Dunkel' : 'Hell'),
+              value: Theme.of(context).brightness == Brightness.dark,
+              onChanged: (isDark) {
+                themeNotifier.setTheme(isDark ? ThemeMode.dark : ThemeMode.light);
+              },
+            ),
+            const Divider(height: 1),
+            ListTile(
+              title: const Text('Benachrichtigungen'),
+              subtitle: settingsState.settings.notificationsEnabled
+                  ? Text('Aktiviert um ${settingsState.settings.notificationTime} Uhr')
+                  : const Text('Deaktiviert'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () {
+                NotificationSettingsDialog.show(context, settingsState.settings);
+              },
+            ),
+            const Divider(height: 1),
+            FutureBuilder<PackageInfo>(
+              future: PackageInfo.fromPlatform(),
+              builder: (context, snapshot) {
+                final version = snapshot.data?.version ?? '...';
+                return ListTile(
+                  title: const Text('Version'),
+                  trailing: Text(version),
+                );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.shop, color: Colors.green),
+              title: const Text('App im Google Play Store herunterladen'),
+              subtitle: const Text('Installieren Sie die offizielle Android-App'),
+              trailing: const Icon(Icons.open_in_new),
+              onTap: () async {
+                final url = Uri.parse(
+                  'https://play.google.com/store/apps/details?id=app.work_time_manager',
+                );
+                if (await canLaunchUrl(url)) {
+                  await launchUrl(url, mode: LaunchMode.externalApplication);
+                }
+              },
+            ),
+            const Divider(height: 1),
+            if (kDebugMode)
+              ListTile(
+                leading: const Icon(Icons.bug_report, color: Colors.orange),
+                title: const Text('🧪 TEST: Version Check'),
+                subtitle: const Text('Update-Dialog manuell anzeigen'),
+                onTap: () async {
+                  final versionService = ref.read(core_providers.versionServiceProvider);
+                  await UpdateRequiredDialog.checkAndShow(context, versionService);
+                },
+              ),
+            ListTile(
+              title: const Text('Impressum'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => ImprintDialog.show(context),
+            ),
+            ListTile(
+              title: const Text('AGB'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => TermsOfServiceDialog.show(context),
+            ),
+            ListTile(
+              title: const Text('Datenschutz'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => PrivacyPolicyDialog.show(context),
+            ),
+            if (authState.asData?.value != null) ...[
+              const Divider(height: 1),
+              ListTile(
+                leading: Icon(Icons.delete_forever, color: theme.colorScheme.error),
+                title: Text('Account löschen', style: TextStyle(color: theme.colorScheme.error)),
+                onTap: () {
+                  showDialog(
+                    context: context,
+                    builder: (dialogContext) => AlertDialog(
+                      title: const Text('Account endgültig löschen'),
+                      content: const Text(
+                          'Warnung: Diese Aktion kann nicht rückgängig gemacht werden. Alle Ihre Daten, einschließlich der Arbeitszeiterfassung, werden dauerhaft gelöscht.'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.of(dialogContext).pop(),
+                          child: const Text('Abbrechen'),
                         ),
-                      );
-                    },
-                  ),
-                ],
-              ],
+                        FilledButton(
+                          onPressed: () {
+                            Navigator.of(dialogContext).pop();
+                            ref.read(deleteAccountProvider)();
+                          },
+                          style: FilledButton.styleFrom(
+                            backgroundColor: theme.colorScheme.error,
+                          ),
+                          child: const Text('Endgültig löschen'),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ],
+          ];
+
+          return ResponsiveCenter(
+            maxContentWidth: 1200,
+            child: LayoutBuilder(
+              builder: (context, constraints) {
+                if (constraints.maxWidth > 900) {
+                  return SingleChildScrollView(
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: leftColumnChildren,
+                          ),
+                        ),
+                        const SizedBox(width: 32),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              // Invisible spacer to match left column's top section
+                              Visibility(
+                                maintainSize: true,
+                                maintainAnimation: true,
+                                maintainState: true,
+                                visible: false,
+                                child: Column(
+                                  children: topSection,
+                                ),
+                              ),
+                              ...rightColumnChildren,
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                } else {
+                  return ListView(
+                    children: [
+                      ...leftColumnChildren,
+                      ...rightColumnChildren,
+                    ],
+                  );
+                }
+              },
             ),
           );
         },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.14.0
+version: 0.15.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
📝 Zusammenfassung
  Dieser Pull Request optimiert die Anwendung massiv für die Web/Desktop-Nutzung durch Einführung von Responsive Layouts für das Dashboard und die Einstellungen. Zusätzlich wurden kritische Fehler im Authentifizierungs-Workflow
  (Login-Redirect bei Berichten, Logout-Crash auf Web) behoben und UI-Inkonsistenzen bereinigt.

  ✨ Änderungen im Detail

  🖥️ Dashboard (dashboard_screen.dart)
   * Responsive Layout: Auf breiten Bildschirmen (>900px) wird nun ein zweispaltiges Layout verwendet.
       * Links: Timer-Anzeige, Anwesenheitsdauer und Überstunden-Statistiken.
       * Rechts: Steuerelemente (Start/Stop, Zeit-Inputs) und Pausen-Liste.
   * Cleanup: Das Einstellungen-Icon wurde aus der AppBar entfernt (da global über die Navigation erreichbar).

  ⚙️ Einstellungen (settings_page.dart)
   * Responsive Layout: Zweispaltiges Design für Web/Desktop.
       * Links: Profil, Login/Logout, Arbeitszeit-Einstellungen, Sync.
       * Rechts: Design, Benachrichtigungen, Rechtliches.
   * Layout-Optimierung: 
       * Die rechte Spalte beginnt nun vertikal bündig mit den "Soll-Arbeitsstunden" der linken Spalte (durch einen unsichtbaren Spacer).
       * Unified Scrolling: Anstatt zwei separat scrollbarer Spalten scrollt nun die gesamte Seite als eine Einheit.
   * Bugfix: Der Design-Switch zeigt nun korrekt "Dunkel" an, auch wenn der Modus durch die Systemeinstellung ("System") gesteuert wird (Theme.of(context).brightness).

  📊 Berichte (reports_page.dart)
   * Auth-Workflow Fix: Der "Bouncing"-Fehler beim Tab-Wechsel wurde behoben.
       * Die aggressive automatische Umleitung auf den ersten Tab wurde entfernt.
       * Stattdessen zeigen die Tabs (Wöchentlich/Monatlich) nun direkt einen "Anmeldung erforderlich"-Screen.
       * Nach dem Login wird der Nutzer korrekt auf den ursprünglich gewählten Tab zurückgeleitet.
   * UI Polish: Die Buttons "Eintrag hinzufügen" und "Schnell-Eintrag" haben nun ein einheitliches Design (Breite, Icons, Styling) in der Tagesansicht und im BottomSheet.

  🔐 Authentifizierung & Core
   * Web Sign-Out Fix: Absturz beim Ausloggen in der Web-Version behoben. Der Aufruf von google_sign_in.signOut() wird auf Web nun übersprungen, da dort ausschließlich Firebase Auth verwendet wird.

  🐛 Behobene Fehler
   * Fixes  - Logout Crash auf Web (Bad state: GoogleSignInPlugin::init()...).
   * Fixes  - Login-Loop und falscher Tab-Reset in der Berichte-Ansicht.
   * Fixes  - Theme-Switch State war inkonsistent zum tatsächlichen Dark Mode.
close #18 