### PR TITLE
Release/release.0.18.1

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,8 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:purchases_flutter/purchases_flutter.dart';
 import 'dart:io' show Platform;
 
+import 'package:flutter_localizations/flutter_localizations.dart';
+
 import 'core/config/google_sign_in_config.dart';
 import 'core/providers/providers.dart';
 import 'core/services/notification_service.dart';
@@ -150,6 +152,15 @@ class MyApp extends ConsumerWidget {
       theme: AppTheme.lightTheme,
       darkTheme: AppTheme.darkTheme,
       themeMode: themeMode,
+      locale: const Locale('de', 'DE'),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('de', 'DE'),
+      ],
       home: const HomeScreen(),
     );
   }

--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -50,7 +50,10 @@ class DashboardScreen extends ConsumerWidget {
       return prev + end.difference(b.start);
     });
 
-    final grossDuration = dashboardState.grossWorkDuration ?? (netDuration + totalBreakDuration);
+    final grossDuration = dashboardState.grossWorkDuration ??
+        (workEntry.workStart != null && workEntry.workEnd != null
+            ? workEntry.workEnd!.difference(workEntry.workStart!)
+            : (netDuration + totalBreakDuration));
 
     return Scaffold(
       appBar: AppBar(

--- a/lib/presentation/view_models/dashboard_view_model.dart
+++ b/lib/presentation/view_models/dashboard_view_model.dart
@@ -303,7 +303,10 @@ class DashboardViewModel extends Notifier<DashboardState> {
 
     final settingsRepository = ref.read(settingsRepositoryProvider);
 
+    Duration? newGrossWorkDuration;
     if (updatedEntry.workStart != null && updatedEntry.workEnd != null) {
+      newGrossWorkDuration = updatedEntry.workEnd!.difference(updatedEntry.workStart!);
+      
       final breakDuration = updatedEntry.breaks.fold<Duration>(
         Duration.zero,
         (previousValue, element) => previousValue + (element.end?.difference(element.start) ?? Duration.zero),
@@ -327,6 +330,12 @@ class DashboardViewModel extends Notifier<DashboardState> {
       }
     } else {
       newActualWorkDuration = null;
+      // Wenn der Timer läuft, wird grossWorkDuration vom Timer aktualisiert.
+      // Wir setzen es hier auf null, damit der Timer (oder die UI Logik) übernimmt.
+      // Außer wir wollen einen initialen Wert für den Start setzen?
+      // Der Timer startet sofort in _startTimerIfNeeded und setzt den Wert.
+      newGrossWorkDuration = null;
+      
       // dailyOvertime bleibt null oder wird neu berechnet wenn Timer läuft, 
       // aber hier (bei Start/Stop) ist es nur relevant wenn gestoppt.
       // Wenn gestartet: dailyOvertime wird im Timer Loop berechnet.
@@ -335,6 +344,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     state = state.copyWith(
       workEntry: updatedEntry,
       actualWorkDuration: newActualWorkDuration,
+      grossWorkDuration: newGrossWorkDuration,
       totalOvertime: newTotalOvertime,
       dailyOvertime: dailyOvertime,
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.17.0
+version: 0.18.1
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
 Beschreibung
  Dieser PR behebt Fehler bei der Anzeige der Brutto-Arbeitszeit im Dashboard und stellt die App vollständig auf die deutsche Sprache ein, insbesondere für
  System-Dialoge.

  Änderungen

  1. Korrektur der "Anwesenheit (Brutto)"
   * Problem: Der Wert für "Anwesenheit (Brutto)" wurde indirekt berechnet und aktualisierte sich bei manueller Eingabe der Endzeit nicht sofort, da er noch auf den
     letzten Stand des laufenden Timers fixiert war.
   * Lösung: 
       * Im DashboardViewModel wird die grossWorkDuration nun bei jeder Neuberechnung (z. B. nach manueller Zeiteingabe) explizit aktualisiert.
       * Im DashboardScreen wurde die Logik so angepasst, dass sie die direkte Differenz zwischen Start- und Endzeit bevorzugt, um Rundungsdifferenzen durch
         Pausenregeln zu vermeiden.

  2. Vollständige deutsche Lokalisierung (Inputs)
   * Problem: System-Widgets wie der TimePicker oder der DatePicker wurden teilweise noch auf Englisch (AM/PM) angezeigt.
   * Lösung:
       * flutter_localizations wurde in der MaterialApp konfiguriert.
       * Die App ist nun fest auf de_DE eingestellt, sodass alle Standard-Dialoge, Monatsnamen und Zeitformate (24h) korrekt auf Deutsch erscheinen.

  3. Code-Qualität
   * Bestehende Unit-Tests für den BreakCalculatorService und das DashboardViewModel wurden erfolgreich ausgeführt, um sicherzustellen, dass die Kernlogik weiterhin
     stabil ist.