### PR TITLE
Style: Highlight delete button in daily reports with red color

### DIFF
--- a/lib/presentation/screens/reports_page.dart
+++ b/lib/presentation/screens/reports_page.dart
@@ -415,7 +415,8 @@ class DailyReportView extends ConsumerWidget {
                                   onPressed: () => onEntryTap(entry),
                                 ),
                                 IconButton(
-                                  icon: const Icon(Icons.delete),
+                                  icon: Icon(Icons.delete,
+                                      color: Colors.red.shade700),
                                   onPressed: () =>
                                       _confirmDelete(context, ref, entry),
                                 ),
@@ -1554,7 +1555,8 @@ class _DayEntriesBottomSheetState extends ConsumerState<DayEntriesBottomSheet> {
                                   onPressed: () => _openEdit(entry),
                                 ),
                                 IconButton(
-                                  icon: const Icon(Icons.delete),
+                                  icon: Icon(Icons.delete,
+                                      color: Colors.red.shade700),
                                   onPressed: () =>
                                       _confirmDelete(ctx, ref, entry),
                                 ),


### PR DESCRIPTION
- Improve visibility of delete button for work entries in reports
- Apply consistent red color (Colors.red.shade700) to delete icons
close #19