### PR TITLE
Add reset button for overtime balance and allow zero values 

### DIFF
--- a/lib/presentation/widgets/add_adjustment_modal.dart
+++ b/lib/presentation/widgets/add_adjustment_modal.dart
@@ -24,14 +24,6 @@ class _AddAdjustmentModalState extends ConsumerState<AddAdjustmentModal> {
   }
 
   void _save() {
-    // Überprüfen auf leere Eingaben
-    if (_hoursController.text.isEmpty && _minutesController.text.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Bitte geben Sie mindestens Stunden oder Minuten ein')),
-      );
-      return;
-    }
-
     // Stunden und Minuten als positive Werte parsen
     int parsedHours = int.tryParse(_hoursController.text) ?? 0;
     int parsedMinutes = int.tryParse(_minutesController.text) ?? 0;
@@ -40,14 +32,6 @@ class _AddAdjustmentModalState extends ConsumerState<AddAdjustmentModal> {
     if (parsedMinutes > 59) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Minuten müssen zwischen 0 und 59 liegen')),
-      );
-      return;
-    }
-
-    // Mindestens einer der Werte muss größer als 0 sein
-    if (parsedHours == 0 && parsedMinutes == 0) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Bitte geben Sie einen Wert größer als 0 ein')),
       );
       return;
     }
@@ -65,6 +49,16 @@ class _AddAdjustmentModalState extends ConsumerState<AddAdjustmentModal> {
     }
   }
 
+  void _reset() {
+    // Setze die Gleitzeit-Bilanz auf 0 zurück
+    ref.read(settingsViewModelProvider.notifier).setOvertimeBalance(ref, Duration.zero);
+
+    // Modal schließen
+    if (mounted) {
+      Navigator.of(context).pop();
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -74,7 +68,7 @@ class _AddAdjustmentModalState extends ConsumerState<AddAdjustmentModal> {
           mainAxisSize: MainAxisSize.min,
           children: [
           const Text(
-            'Manuelle Eingabe für den heutigen Tag. Wählen Sie zuerst Überstunden oder Minusstunden.',
+            'Geben Sie einen neuen Wert ein oder setzen Sie die Bilanz auf 0 zurück.',
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 16),
@@ -163,6 +157,10 @@ class _AddAdjustmentModalState extends ConsumerState<AddAdjustmentModal> {
         ],
       )),
       actions: [
+        TextButton(
+          onPressed: _reset,
+          child: const Text('Auf 0 zurücksetzen'),
+        ),
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('Abbrechen'),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.19.2
+version: 0.19.3
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
- Add "Auf 0 zurücksetzen" (Reset to 0) button to the overtime adjustment modal
    - Remove validation that blocked saving zero values
    - Update helper text to reflect new functionality

  Problem

  Previously, users had no way to reset or clear their overtime balance:
    - Saving 0 hours/0 minutes was blocked by validation
    - No reset button was available
    - Incorrect entries could only be corrected via workarounds (e.g., setting 1 minute or adjusting individual time entries)

  Solution

  The overtime adjustment modal now provides two ways to set the balance to zero:

    1. Reset button - New "Auf 0 zurücksetzen" button directly sets the balance to 0
    2. Save zero - Users can now save 0h 0m as a valid value

  Updated modal actions:                                                                                                                                                                                                            
  [Auf 0 zurücksetzen] [Abbrechen] [Speichern]

  Changed Files

    - lib/presentation/widgets/add_adjustment_modal.dart
        - Added _reset() method
        - Removed zero-value validation
        - Added reset button to actions
        - Updated helper text

  Test plan

    - Open Settings → "Überstunden / Minusstunden anpassen"
    - Verify "Auf 0 zurücksetzen" button is visible
    - Click reset button → verify balance is set to 0
    - Enter 0 hours, 0 minutes → click save → verify it works (no error)
    - Enter valid values → verify normal save still works

  Closes #111      