### PR TITLE
Weiche Warnung bei unzureichenden Pausenzeiten (Arbeitszeitgesetz)

### DIFF
--- a/lib/domain/services/break_calculator_service.dart
+++ b/lib/domain/services/break_calculator_service.dart
@@ -3,12 +3,56 @@ import 'package:flutter_work_time/core/utils/logger.dart';
 import '../entities/break_entity.dart';
 import '../entities/work_entry_entity.dart';
 
+/// Ergebnis der Pausen-Validierung gemäß Arbeitszeitgesetz
+class BreakComplianceResult {
+  final bool isCompliant;
+  final Duration requiredBreakTime;
+  final Duration actualBreakTime;
+  final Duration missingBreakTime;
+
+  const BreakComplianceResult({
+    required this.isCompliant,
+    required this.requiredBreakTime,
+    required this.actualBreakTime,
+    required this.missingBreakTime,
+  });
+}
+
 class BreakCalculatorService {
   static const Duration minWorkTimeForFirstBreak = Duration(hours: 6);
   static const Duration minWorkTimeForSecondBreak = Duration(hours: 9);
   static const Duration firstBreakDuration = Duration(minutes: 30); // Gesetzlich vorgeschriebene Pausenzeit bei 6+ Stunden
   static const Duration secondBreakDuration = Duration(minutes: 15);
   static const Duration requiredBreakTimeForLongDay = Duration(minutes: 45); // Gesetzlich vorgeschriebene Pausenzeit bei 9+ Stunden
+
+  /// Prüft, ob die Pausen den Anforderungen des Arbeitszeitgesetzes entsprechen.
+  /// Gibt ein BreakComplianceResult mit Details zur Compliance zurück.
+  ///
+  /// WICHTIG: Das Arbeitszeitgesetz bezieht sich auf die EFFEKTIVE Arbeitszeit
+  /// (Netto = ohne Pausen), nicht auf die Anwesenheitszeit (Brutto).
+  static BreakComplianceResult validateBreakCompliance(WorkEntryEntity entry) {
+    final actualBreakTime = entry.totalBreakTime;
+    // Verwende effektive Arbeitszeit (Netto) für die Berechnung
+    final effectiveWorkTime = entry.effectiveWorkDuration;
+
+    // Berechne die erforderliche Pausenzeit basierend auf der Netto-Arbeitszeit
+    Duration requiredBreakTime = Duration.zero;
+    if (effectiveWorkTime >= minWorkTimeForSecondBreak) {
+      requiredBreakTime = requiredBreakTimeForLongDay; // 45 Min bei 9+ Stunden Netto
+    } else if (effectiveWorkTime >= minWorkTimeForFirstBreak) {
+      requiredBreakTime = firstBreakDuration; // 30 Min bei 6-9 Stunden Netto
+    }
+
+    final missingBreakTime = requiredBreakTime - actualBreakTime;
+    final isCompliant = missingBreakTime <= Duration.zero;
+
+    return BreakComplianceResult(
+      isCompliant: isCompliant,
+      requiredBreakTime: requiredBreakTime,
+      actualBreakTime: actualBreakTime,
+      missingBreakTime: isCompliant ? Duration.zero : missingBreakTime,
+    );
+  }
 
   /// Berechnet die automatischen Pausen basierend auf der Arbeitszeit
   /// und gibt einen aktualisierten WorkEntryEntity zurück.

--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -301,7 +301,7 @@ class DashboardScreen extends ConsumerWidget {
                       },
                     ),
                     IconButton(
-                      icon: const Icon(Icons.delete),
+                      icon: Icon(Icons.delete, color: Colors.red.shade700),
                       onPressed: () => dashboardViewModel.deleteBreak(b.id),
                     ),
                   ],

--- a/lib/presentation/widgets/dashboard/breaks_card.dart
+++ b/lib/presentation/widgets/dashboard/breaks_card.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 
 import '../../../domain/entities/break_entity.dart';
 import '../../../domain/entities/work_entry_entity.dart';
+import '../../../domain/services/break_calculator_service.dart';
 import '../../view_models/dashboard_view_model.dart';
 
 /// Eine Karte zur Anzeige und Verwaltung von Pausen.
@@ -60,6 +61,8 @@ class BreaksCard extends ConsumerWidget {
                 ),
               ),
             ),
+            // Warnung bei unzureichenden Pausen (Arbeitszeitgesetz)
+            _buildBreakComplianceWarning(context),
             const SizedBox(height: 16),
             ElevatedButton.icon(
               icon: Icon(
@@ -80,6 +83,52 @@ class BreaksCard extends ConsumerWidget {
                 // Rufe die neue ViewModel-Methode auf, die wir erstellt haben.
                 ref.read(dashboardViewModelProvider.notifier).startOrStopBreak();
               },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Zeigt eine Warnung an, wenn die Pausen nicht den Anforderungen
+  /// des Arbeitszeitgesetzes entsprechen.
+  Widget _buildBreakComplianceWarning(BuildContext context) {
+    // Nur prüfen, wenn Arbeit gestartet wurde
+    if (workEntry.workStart == null) {
+      return const SizedBox.shrink();
+    }
+
+    final compliance = BreakCalculatorService.validateBreakCompliance(workEntry);
+
+    // Keine Warnung nötig, wenn Pausen ausreichend sind oder keine Pause erforderlich ist
+    if (compliance.isCompliant || compliance.requiredBreakTime == Duration.zero) {
+      return const SizedBox.shrink();
+    }
+
+    final missingMinutes = compliance.missingBreakTime.inMinutes;
+    final requiredMinutes = compliance.requiredBreakTime.inMinutes;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 12.0),
+      child: Container(
+        padding: const EdgeInsets.all(12.0),
+        decoration: BoxDecoration(
+          color: Colors.orange.shade50,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.orange.shade200),
+        ),
+        child: Row(
+          children: [
+            Icon(Icons.info_outline, color: Colors.orange.shade700, size: 20),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                'Hinweis: Laut Arbeitszeitgesetz sind bei dieser Arbeitszeit mind. $requiredMinutes Min. Pause vorgeschrieben. Es fehlen noch $missingMinutes Min.',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.orange.shade900,
+                ),
+              ),
             ),
           ],
         ),

--- a/lib/presentation/widgets/edit_work_entry_modal.dart
+++ b/lib/presentation/widgets/edit_work_entry_modal.dart
@@ -234,7 +234,7 @@ class EditWorkEntryModal extends ConsumerWidget {
               ),
             ),
             IconButton(
-              icon: const Icon(Icons.delete, color: Colors.red),
+              icon: Icon(Icons.delete, color: Colors.red.shade700),
               onPressed: () => viewModel.deleteBreak(breakEntry.id),
             ),
           ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.19.3
+version: 0.20.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Zusammenfassung

- Weiche Warnung in der Pausen-Karte, wenn Pausen nicht dem Arbeitszeitgesetz entsprechen
- Neue validateBreakCompliance() Methode im BreakCalculatorService
- Berechnung basiert auf Netto-Arbeitszeit (effektiv), nicht Brutto (Anwesenheit)
- Einheitliche rote Farbe für alle Lösch-Buttons

Arbeitszeitgesetz (§4 ArbZG)                                                                                                                                                                                                      
┌───────────────────┬─────────────────────┐                                                                                                                                                                                       
│ Netto-Arbeitszeit │ Erforderliche Pause │                                                                                                                                                                                       
├───────────────────┼─────────────────────┤                                                                                                                                                                                       
│ < 6h              │ Keine               │                                                                                                                                                                                       
├───────────────────┼─────────────────────┤                                                                                                                                                                                       
│ 6h - 9h           │ 30 Min              │                                                                                                                                                                                       
├───────────────────┼─────────────────────┤                                                                                                                                                                                       
│ ≥ 9h              │ 45 Min              │                                                                                                                                                                                       
└───────────────────┴─────────────────────┘                                                                                                                                                                                       
Funktionen

Weiche Warnung

Wenn Pausen unzureichend sind, erscheint ein orangefarbenes Info-Banner:                                                                                                                                                          
ⓘ Hinweis: Laut Arbeitszeitgesetz sind bei dieser Arbeitszeit                                                                                                                                                                     
mind. 30 Min. Pause vorgeschrieben. Es fehlen noch 15 Min.

Einheitliche Lösch-Buttons

Alle Lösch-Buttons verwenden jetzt Colors.red.shade700:
- Dashboard Pausenliste
- Eintrag bearbeiten Modal (Pausen)
- Tagesberichte (Arbeitseinträge)
- Bottom Sheet (Arbeitseinträge)

Geänderte Dateien                                                                                                                                                                                                                 
┌───────────────────────────────┬─────────────────────────────────────────────────────────────────────────┐                                                                                                                       
│             Datei             │                                Änderung                                 │                                                                                                                       
├───────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤                                                                                                                       
│ break_calculator_service.dart │ Neue BreakComplianceResult Klasse und validateBreakCompliance() Methode │                                                                                                                       
├───────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤                                                                                                                       
│ breaks_card.dart              │ Neue _buildBreakComplianceWarning() Methode                             │                                                                                                                       
├───────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤                                                                                                                       
│ dashboard_screen.dart         │ Roter Lösch-Button für Pausen                                           │                                                                                                                       
├───────────────────────────────┼─────────────────────────────────────────────────────────────────────────┤                                                                                                                       
│ edit_work_entry_modal.dart    │ Einheitlicher roter Lösch-Button                                        │                                                                                                                       
└───────────────────────────────┴─────────────────────────────────────────────────────────────────────────┘                                                                                                                       
Testplan

- 6+ Stunden arbeiten mit < 30 Min Pause → Warnung erscheint
- 9+ Stunden (Netto) arbeiten mit < 45 Min Pause → Warnung zeigt 45 Min erforderlich
- Ausreichend Pausen hinzufügen → Warnung verschwindet
- Alle Lösch-Buttons sind rot (Dashboard, Berichte, Modals)
- Bestehende Break Calculator Tests laufen

close #114 