### PR TITLE
Voraussichtlicher Feierabend ausblenden nach Arbeitsende 

### DIFF
--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -87,8 +87,11 @@ class DashboardScreen extends ConsumerWidget {
               _buildOvertime(context, totalOvertime, 'Überstunden Gesamt'),
               const SizedBox(height: 16),
               _buildOvertime(context, dashboardState.dailyOvertime, 'Heutige Überstunden'),
-              _buildExpectedEndTime(context, dashboardState.expectedEndTime),
-              _buildExpectedEndTimeWithBalance(context, dashboardState.expectedEndTotalZero),
+              // Voraussichtlichen Feierabend nur anzeigen, wenn Arbeit noch läuft
+              if (workEntry.workEnd == null) ...[
+                _buildExpectedEndTime(context, dashboardState.expectedEndTime),
+                _buildExpectedEndTimeWithBalance(context, dashboardState.expectedEndTotalZero),
+              ],
             ],
           );
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.20.0
+version: 0.20.1
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
- "Voraussichtlicher Feierabend"-Hinweis wird ausgeblendet, sobald eine Endzeit gesetzt wurde
    - Beide Hinweise betroffen: "Voraussichtlicher Feierabend (±0)" und "Mit Gleitzeit-Bilanz auf 0"

  Problem

  Der Hinweis auf den voraussichtlichen Feierabend blieb sichtbar, auch nachdem die Arbeit beendet wurde. Das führte zu veralteten/irrelevanten Informationen, wenn die angezeigte Zeit bereits vergangen war.

  Vorher:                                                                                                                                                                                                                           
  Arbeit beendet um 17:00                                                                                                                                                                                                           
  Voraussichtlicher Feierabend (±0): 16:45 Uhr  ← irrelevant

  Nachher:                                                                                                                                                                                                                          
  Arbeit beendet um 17:00                                                                                                                                                                                                           
  (kein Hinweis mehr)

  Lösung

  Bedingung hinzugefügt, die prüft ob workEntry.workEnd == null:
    - Arbeit läuft → Hinweis wird angezeigt
    - Arbeit beendet → Hinweis wird ausgeblendet

  Geänderte Dateien

    - lib/presentation/screens/dashboard_screen.dart

  Testplan

    - Arbeit starten → Voraussichtlicher Feierabend wird angezeigt
    - Endzeit manuell setzen → Hinweis verschwindet
    - Endzeit wieder löschen → Hinweis erscheint wieder

  close #115         