### PR TITLE
Zeiterfassung-Button startet neue Session nach Beendigung

### DIFF
--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -113,7 +113,14 @@ class DashboardScreen extends ConsumerWidget {
               ),
               const SizedBox(height: 24),
               ElevatedButton(
-                onPressed: () => dashboardViewModel.startOrStopTimer(),
+                onPressed: () {
+                  // Wenn Arbeit bereits beendet wurde, zeige Bestätigungsdialog
+                  if (workEntry.workStart != null && workEntry.workEnd != null) {
+                    _showRestartDialog(context, dashboardViewModel);
+                  } else {
+                    dashboardViewModel.startOrStopTimer();
+                  }
+                },
                 style: ElevatedButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 16),
                 ),
@@ -312,6 +319,40 @@ class DashboardScreen extends ConsumerWidget {
               ),
             )),
       ],
+    );
+  }
+
+  void _showRestartDialog(BuildContext context, DashboardViewModel viewModel) {
+    showDialog(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Neue Session starten'),
+        content: const Text(
+          'Möchten Sie eine neue Session starten?\n\n'
+          '• Pausen behalten: Nur Start- und Endzeit werden zurückgesetzt\n'
+          '• Komplett neu: Start, End und Pausen werden zurückgesetzt',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(),
+            child: const Text('Abbrechen'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              viewModel.startNewSessionKeepBreaks();
+            },
+            child: const Text('Pausen behalten'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(dialogContext).pop();
+              viewModel.startNewSession();
+            },
+            child: const Text('Komplett neu'),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/presentation/view_models/dashboard_view_model.dart
+++ b/lib/presentation/view_models/dashboard_view_model.dart
@@ -273,11 +273,11 @@ class DashboardViewModel extends Notifier<DashboardState> {
     WorkEntryEntity updatedEntry;
 
     if (state.workEntry.workStart == null) {
-      // START
+      // START - Erster Start des Tages
       updatedEntry = state.workEntry.copyWith(workStart: now);
       logger.i('[Dashboard] Timer gestartet um $now');
-    } else {
-      // STOP
+    } else if (state.workEntry.workEnd == null) {
+      // STOP - Arbeit beenden
       _timer?.cancel();
       updatedEntry = state.workEntry.copyWith(workEnd: now);
       logger.i('[Dashboard] Timer gestoppt um $now');
@@ -291,8 +291,49 @@ class DashboardViewModel extends Notifier<DashboardState> {
       } else {
         logger.i('[Dashboard] Automatische Pausen übersprungen: Pause läuft noch');
       }
+    } else {
+      // Arbeit wurde bereits beendet - Benutzer muss entscheiden
+      // Diese Methode wird vom UI mit dem gewählten Modus aufgerufen
+      logger.i('[Dashboard] Arbeit bereits beendet - Benutzer muss Aktion wählen');
+      return; // UI zeigt Dialog an
     }
 
+    await _recalculateStateAndSave(updatedEntry);
+  }
+
+  /// Startet eine komplett neue Session (Start, End und Pausen zurücksetzen)
+  Future<void> startNewSession() async {
+    final now = DateTime.now();
+    final updatedEntry = WorkEntryEntity(
+      id: state.workEntry.id,
+      date: state.workEntry.date,
+      workStart: now,
+      workEnd: null,
+      breaks: const [], // Pausen zurücksetzen
+      manualOvertime: state.workEntry.manualOvertime,
+      isManuallyEntered: false,
+      description: state.workEntry.description,
+      type: state.workEntry.type,
+    );
+    logger.i('[Dashboard] Komplett neue Session gestartet um $now (Start, End, Pausen zurückgesetzt)');
+    await _recalculateStateAndSave(updatedEntry);
+  }
+
+  /// Neue Session mit Pausen behalten (nur Start und Endzeit zurücksetzen)
+  Future<void> startNewSessionKeepBreaks() async {
+    final now = DateTime.now();
+    final updatedEntry = WorkEntryEntity(
+      id: state.workEntry.id,
+      date: state.workEntry.date,
+      workStart: now,
+      workEnd: null, // Endzeit entfernen
+      breaks: state.workEntry.breaks, // Pausen behalten
+      manualOvertime: state.workEntry.manualOvertime,
+      isManuallyEntered: false,
+      description: state.workEntry.description,
+      type: state.workEntry.type,
+    );
+    logger.i('[Dashboard] Neue Session gestartet um $now (Pausen behalten)');
     await _recalculateStateAndSave(updatedEntry);
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.20.1
+version: 0.21.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
- Korrektur: Button "Zeiterfassung starten" startet jetzt korrekt eine neue Session nach Beendigung
    - Neuer Bestätigungsdialog mit zwei Optionen beim Neustart
    - Benutzer kann wählen ob Pausen behalten oder alles zurückgesetzt werden soll

  Problem

  Nach dem Beenden der Zeiterfassung und erneutem Klick auf "Zeiterfassung starten" wurde nur die Endzeit neu gesetzt, nicht die Startzeit. Die Startzeit musste manuell angepasst werden.

  Vorher:
    1. Klick → Startzeit gesetzt (8:00)
    2. Klick → Endzeit gesetzt (17:00) ✓
    3. Klick → Endzeit überschrieben (17:05) ✗ (erwartet: neue Startzeit)

  Nachher:
    1. Klick → Startzeit gesetzt (8:00)
    2. Klick → Endzeit gesetzt (17:00) ✓
    3. Klick → Dialog erscheint mit Optionen ✓

  Lösung

  Drei Zustände werden jetzt unterschieden:                                                                                                                                                                                         
  ┌────────────────────────────────────┬──────────────────┐                                                                                                                                                                         
  │              Zustand               │      Aktion      │                                                                                                                                                                         
  ├────────────────────────────────────┼──────────────────┤                                                                                                                                                                         
  │ workStart == null                  │ Startzeit setzen │                                                                                                                                                                         
  ├────────────────────────────────────┼──────────────────┤                                                                                                                                                                         
  │ workStart != null, workEnd == null │ Endzeit setzen   │                                                                                                                                                                         
  ├────────────────────────────────────┼──────────────────┤                                                                                                                                                                         
  │ workStart != null, workEnd != null │ Dialog anzeigen  │                                                                                                                                                                         
  └────────────────────────────────────┴──────────────────┘                                                                                                                                                                         
  Dialog-Optionen:                                                                                                                                                                                                                  
  ┌─────────────────┬────────┬────────┬──────────┐                                                                                                                                                                                  
  │     Button      │ Start  │  End   │  Pausen  │                                                                                                                                                                                  
  ├─────────────────┼────────┼────────┼──────────┤                                                                                                                                                                                  
  │ Abbrechen       │ bleibt │ bleibt │ bleiben  │                                                                                                                                                                                  
  ├─────────────────┼────────┼────────┼──────────┤                                                                                                                                                                                  
  │ Pausen behalten │ jetzt  │ null   │ bleiben  │                                                                                                                                                                                  
  ├─────────────────┼────────┼────────┼──────────┤                                                                                                                                                                                  
  │ Komplett neu    │ jetzt  │ null   │ gelöscht │                                                                                                                                                                                  
  └─────────────────┴────────┴────────┴──────────┘                                                                                                                                                                                  
  Geänderte Dateien

    - lib/presentation/view_models/dashboard_view_model.dart - Neue Methoden startNewSession() und startNewSessionKeepBreaks()
    - lib/presentation/screens/dashboard_screen.dart - Dialog _showRestartDialog() hinzugefügt

  Testplan

    - Zeiterfassung starten → Startzeit wird gesetzt
    - Zeiterfassung beenden → Endzeit wird gesetzt
    - Erneut auf "Zeiterfassung starten" klicken → Dialog erscheint
    - "Abbrechen" → Keine Änderung
    - "Pausen behalten" → Neue Startzeit, Pausen bleiben
    - "Komplett neu" → Neue Startzeit, Pausen werden gelöscht

  close #118 