### PR TITLE
Schnell-Eintrag: Multi-Selektion & Bugfixes Urlaub/Krank   

### DIFF
--- a/lib/data/repositories/local_work_repository_impl.dart
+++ b/lib/data/repositories/local_work_repository_impl.dart
@@ -51,6 +51,12 @@ class LocalWorkRepositoryImpl implements WorkRepository {
           : null,
       description: data['description'] as String?,
       isManuallyEntered: data['isManuallyEntered'] as bool? ?? false,
+      type: data['type'] != null
+          ? WorkEntryType.values.firstWhere(
+              (e) => e.name == data['type'],
+              orElse: () => WorkEntryType.work,
+            )
+          : WorkEntryType.work,
     );
   }
 
@@ -63,6 +69,7 @@ class LocalWorkRepositoryImpl implements WorkRepository {
       'manualOvertimeMinutes': entry.manualOvertime?.inMinutes,
       'description': entry.description,
       'isManuallyEntered': entry.isManuallyEntered,
+      'type': entry.type.name,
     };
   }
 

--- a/lib/presentation/screens/dashboard_screen.dart
+++ b/lib/presentation/screens/dashboard_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../domain/entities/break_entity.dart';
+import '../../domain/entities/work_entry_entity.dart';
 import '../../domain/services/break_calculator_service.dart';
 import '../view_models/dashboard_view_model.dart';
 import '../widgets/common/responsive_center.dart';
@@ -35,7 +36,7 @@ class DashboardScreen extends ConsumerWidget {
     final dashboardViewModel = ref.read(dashboardViewModelProvider.notifier);
     final workEntry = dashboardState.workEntry;
 
-    final workEntryWithAutoBreaks = workEntry.workStart != null && workEntry.workEnd != null
+    final workEntryWithAutoBreaks = workEntry.workStart != null && workEntry.workEnd != null && workEntry.type == WorkEntryType.work
         ? BreakCalculatorService.calculateAndApplyBreaks(workEntry)
         : workEntry;
 

--- a/lib/presentation/screens/reports_page.dart
+++ b/lib/presentation/screens/reports_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
@@ -7,12 +8,14 @@ import '../../core/providers/subscription_provider.dart';
 
 import '../../domain/entities/work_entry_extensions.dart';
 import '../widgets/common/responsive_center.dart';
+import '../state/reports_state.dart';
 import '../view_models/reports_view_model.dart';
 import '../view_models/settings_view_model.dart';
 import '../view_models/auth_view_model.dart';
 import '../widgets/common/loading_indicator.dart';
 import '../widgets/edit_work_entry_modal.dart';
 import '../widgets/quick_entry_dialog.dart';
+import '../widgets/batch_quick_entry_dialog.dart';
 import '../../domain/entities/work_entry_entity.dart';
 import 'login_page.dart';
 
@@ -245,20 +248,24 @@ class DailyReportView extends ConsumerWidget {
 
         // --- Widgets Construction ---
 
-        final calendarWidget = _Calendar(
-          selectedDate: selectedDay,
-          onDateSelected: (date) => reportsNotifier.selectDate(date),
-          onPreviousMonthTapped: () {
-            final currentMonth = reportsState.selectedMonth ?? DateTime.now();
-            reportsNotifier.onMonthChanged(
-                DateTime(currentMonth.year, currentMonth.month - 1, 1));
-          },
-          onNextMonthTapped: () {
-            final currentMonth = reportsState.selectedMonth ?? DateTime.now();
-            reportsNotifier.onMonthChanged(
-                DateTime(currentMonth.year, currentMonth.month + 1, 1));
-          },
-          daysWithEntries: daysWithEntriesInMonth,
+        final calendarWidget = Column(
+          children: [
+            _Calendar(
+              selectedDate: selectedDay,
+              onDateSelected: (date) => reportsNotifier.selectDate(date),
+              onPreviousMonthTapped: () {
+                final currentMonth = reportsState.selectedMonth ?? DateTime.now();
+                reportsNotifier.onMonthChanged(
+                    DateTime(currentMonth.year, currentMonth.month - 1, 1));
+              },
+              onNextMonthTapped: () {
+                final currentMonth = reportsState.selectedMonth ?? DateTime.now();
+                reportsNotifier.onMonthChanged(
+                    DateTime(currentMonth.year, currentMonth.month + 1, 1));
+              },
+              daysWithEntries: daysWithEntriesInMonth,
+            ),
+          ],
         );
 
         final detailsWidget = Column(
@@ -275,62 +282,91 @@ class DailyReportView extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
                     const Text('Keine Daten für diesen Tag.'),
-                    Builder(builder: (context) {
-                      final today = DateUtils.dateOnly(DateTime.now());
-                      final selectedDateOnly = DateUtils.dateOnly(selectedDay);
-
-                      if (selectedDateOnly.isBefore(today)) {
-                        return Padding(
-                          padding: const EdgeInsets.only(top: 16.0),
-                          child: Column(
-                            children: [
-                              SizedBox(
-                                width: 280,
-                                child: ElevatedButton.icon(
-                                  onPressed: () {
-                                    final newEntry = WorkEntryEntity(
-                                      id: DateFormat('yyyy-MM-dd')
-                                          .format(selectedDay),
-                                      date: selectedDay,
-                                      workStart: null,
-                                      workEnd: null,
-                                      breaks: [],
-                                      isManuallyEntered: true,
-                                      description: null,
-                                      manualOvertime: null,
-                                    );
-                                    onEntryTap(newEntry);
-                                  },
-                                  icon: const Icon(Icons.add),
-                                  label: const Text('Eintrag hinzufügen'),
-                                ),
-                              ),
-                              const SizedBox(height: 12),
-                              SizedBox(
-                                width: 280,
-                                child: ElevatedButton.icon(
-                                  onPressed: () => _handleQuickEntry(
-                                      context, ref, selectedDay),
-                                  icon: const Icon(Icons.flash_on),
-                                  label: const Text(
-                                      'Schnell-Eintrag (Urlaub, Krank...)'),
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-                                    foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
-                                  ),
-                                ),
-                              ),
-                            ],
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16.0),
+                      child: Column(
+                        children: [
+                          SizedBox(
+                            width: 280,
+                            child: ElevatedButton.icon(
+                              onPressed: () {
+                                final newEntry = WorkEntryEntity(
+                                  id: DateFormat('yyyy-MM-dd')
+                                      .format(selectedDay),
+                                  date: selectedDay,
+                                  workStart: null,
+                                  workEnd: null,
+                                  breaks: [],
+                                  isManuallyEntered: true,
+                                  description: null,
+                                  manualOvertime: null,
+                                );
+                                onEntryTap(newEntry);
+                              },
+                              icon: const Icon(Icons.add),
+                              label: const Text('Eintrag hinzufügen'),
+                            ),
                           ),
-                        );
-                      } else {
-                        return const SizedBox.shrink();
-                      }
-                    }),
+                          const SizedBox(height: 12),
+                          SizedBox(
+                            width: 280,
+                            child: ElevatedButton.icon(
+                              onPressed: () async {
+                                if (reportsState.selectedDates.isNotEmpty) {
+                                  await _handleBatchQuickEntry(
+                                      context, ref, reportsState, reportsNotifier);
+                                } else {
+                                  await _handleQuickEntry(
+                                      context, ref, selectedDay);
+                                }
+                              },
+                              icon: const Icon(Icons.flash_on),
+                              label: reportsState.selectedDates.isNotEmpty
+                                  ? Text(
+                                      'Schnell-Eintrag für ${reportsState.selectedDates.length} Tage')
+                                  : const Text('Schnell-Eintrag (Urlaub, Krank...)'),
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Theme.of(context)
+                                    .colorScheme
+                                    .secondaryContainer,
+                                foregroundColor: Theme.of(context)
+                                    .colorScheme
+                                    .onSecondaryContainer,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               )
             else ...[
+              // Batch-Button auch wenn aktueller Tag bereits Einträge hat
+              if (reportsState.selectedDates.isNotEmpty)
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 12.0),
+                    child: SizedBox(
+                      width: 280,
+                      child: ElevatedButton.icon(
+                        onPressed: () async {
+                          await _handleBatchQuickEntry(
+                              context, ref, reportsState, reportsNotifier);
+                        },
+                        icon: const Icon(Icons.flash_on),
+                        label: Text(
+                            'Schnell-Eintrag für ${reportsState.selectedDates.length} Tage'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              Theme.of(context).colorScheme.secondaryContainer,
+                          foregroundColor:
+                              Theme.of(context).colorScheme.onSecondaryContainer,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
               Card(
                 margin: const EdgeInsets.only(bottom: 12.0),
                 child: Padding(
@@ -1129,7 +1165,7 @@ class MonthlyReportView extends ConsumerWidget {
   }
 }
 
-class _Calendar extends StatelessWidget {
+class _Calendar extends ConsumerStatefulWidget {
   final DateTime selectedDate;
   final ValueChanged<DateTime> onDateSelected;
   final VoidCallback? onPreviousMonthTapped;
@@ -1144,6 +1180,16 @@ class _Calendar extends StatelessWidget {
     this.daysWithEntries,
   });
 
+  @override
+  ConsumerState<_Calendar> createState() => _CalendarState();
+}
+
+class _CalendarState extends ConsumerState<_Calendar> {
+  DateTime? _dragStartDate; // Tracks where drag started
+  DateTime? _dragEndDate;   // Tracks current drag position
+  bool _isDragging = false;
+  final GlobalKey _gridKey = GlobalKey();
+
   int _getDaysInMonth(int year, int month) {
     return DateTime(year, month + 1, 0).day;
   }
@@ -1153,8 +1199,125 @@ class _Calendar extends StatelessWidget {
     return weekday - 1;
   }
 
+  /// Prüft, ob ein bestimmtes Datum ein konfigurierter Arbeitstag ist
+  /// Wochentag: 1 = Montag, 7 = Sonntag
+  bool _isWorkday(DateTime date, int workdaysPerWeek) {
+    // Wochentag des Datums (1 = Montag, 7 = Sonntag)
+    int weekday = date.weekday;
+
+    // Arbeitstage sind von Montag (1) bis zu (workdaysPerWeek)
+    // z.B. bei 5 Arbeitstagen: 1-5 (Mo-Fr)
+    return weekday <= workdaysPerWeek;
+  }
+
+  void _selectDateRange(DateTime startDate, DateTime endDate, int workdaysPerWeek) {
+    final reportsNotifier = ref.read(reportsViewModelProvider.notifier);
+
+    // Normalize dates
+    final start = DateTime(startDate.year, startDate.month, startDate.day);
+    final end = DateTime(endDate.year, endDate.month, endDate.day);
+
+    // Ensure start is before end
+    final minDate = start.isBefore(end) ? start : end;
+    final maxDate = start.isBefore(end) ? end : start;
+
+    // Clear previous selection and select all dates in range
+    reportsNotifier.clearDateSelection();
+
+    DateTime currentDate = minDate;
+    while (!currentDate.isAfter(maxDate)) {
+      if (_isWorkday(currentDate, workdaysPerWeek)) {
+        reportsNotifier.addDateToSelection(currentDate);
+      }
+      currentDate = currentDate.add(const Duration(days: 1));
+    }
+  }
+
+  /// Berechnet das Datum anhand einer globalen Bildschirm-Position innerhalb des Kalender-Grids.
+  DateTime? _getDateFromGlobalPosition(Offset globalPosition) {
+    final RenderBox? renderBox =
+        _gridKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null) return null;
+
+    final localPosition = renderBox.globalToLocal(globalPosition);
+    final gridSize = renderBox.size;
+
+    // Außerhalb des Grids → kein Datum
+    if (localPosition.dx < 0 ||
+        localPosition.dy < 0 ||
+        localPosition.dx > gridSize.width ||
+        localPosition.dy > gridSize.height) {
+      return null;
+    }
+
+    // crossAxisCount: 7, childAspectRatio: 1.0 → quadratische Zellen
+    final cellWidth = gridSize.width / 7;
+    final col = (localPosition.dx / cellWidth).floor().clamp(0, 6);
+    final row = (localPosition.dy / cellWidth).floor();
+
+    final gridIndex = row * 7 + col;
+    final firstDayOffset = _getFirstDayOffset(
+      widget.selectedDate.year,
+      widget.selectedDate.month,
+    );
+
+    if (gridIndex < firstDayOffset) return null;
+
+    final day = gridIndex - firstDayOffset + 1;
+    final daysInMonth = _getDaysInMonth(
+      widget.selectedDate.year,
+      widget.selectedDate.month,
+    );
+
+    if (day < 1 || day > daysInMonth) return null;
+
+    return DateTime(widget.selectedDate.year, widget.selectedDate.month, day);
+  }
+
+  void _startDragAt(Offset globalPosition, int workdaysPerWeek) {
+    final date = _getDateFromGlobalPosition(globalPosition);
+    if (date == null || !_isWorkday(date, workdaysPerWeek)) return;
+
+    final reportsNotifier = ref.read(reportsViewModelProvider.notifier);
+    setState(() {
+      _dragStartDate = date;
+      _dragEndDate = date;
+      _isDragging = true;
+    });
+    reportsNotifier.clearDateSelection();
+    reportsNotifier.addDateToSelection(date);
+  }
+
+  void _updateDragAt(Offset globalPosition, int workdaysPerWeek) {
+    if (!_isDragging || _dragStartDate == null) return;
+    final date = _getDateFromGlobalPosition(globalPosition);
+    if (date == null) return;
+    if (!DateUtils.isSameDay(date, _dragEndDate)) {
+      setState(() => _dragEndDate = date);
+      _selectDateRange(_dragStartDate!, date, workdaysPerWeek);
+    }
+  }
+
+  void _endDrag(int workdaysPerWeek) {
+    if (_dragStartDate != null && _dragEndDate != null) {
+      _selectDateRange(_dragStartDate!, _dragEndDate!, workdaysPerWeek);
+    }
+    setState(() {
+      _dragStartDate = null;
+      _dragEndDate = null;
+      _isDragging = false;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    final reportsState = ref.watch(reportsViewModelProvider);
+    final reportsNotifier = ref.read(reportsViewModelProvider.notifier);
+    final settingsState = ref.watch(settingsViewModelProvider);
+
+    // Hole workdaysPerWeek aus den Settings (default 5)
+    final workdaysPerWeek = settingsState.whenData((s) => s.settings.workdaysPerWeek).value ?? 5;
+
     return Card(
       margin: const EdgeInsets.all(8.0),
       child: Padding(
@@ -1166,28 +1329,61 @@ class _Calendar extends StatelessWidget {
               children: [
                 IconButton(
                   icon: const Icon(Icons.chevron_left),
-                  onPressed: onPreviousMonthTapped,
+                  onPressed: widget.onPreviousMonthTapped,
                   tooltip: 'Vorheriger Monat',
                 ),
                 Expanded(
                   child: Text(
-                    DateFormat.yMMMM('de_DE').format(selectedDate),
+                    DateFormat.yMMMM('de_DE').format(widget.selectedDate),
                     style: Theme.of(context).textTheme.titleMedium,
                     textAlign: TextAlign.center,
                   ),
                 ),
                 IconButton(
                   icon: const Icon(Icons.chevron_right),
-                  onPressed: onNextMonthTapped,
+                  onPressed: widget.onNextMonthTapped,
                   tooltip: 'Nächster Monat',
                 ),
               ],
             ),
             const SizedBox(height: 10),
+            // Range Selection Hint
+            if (reportsState.selectedDates.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      '${reportsState.selectedDates.length} Tage ausgewählt',
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.primary,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: () => reportsNotifier.clearDateSelection(),
+                      child: const Text('Zurücksetzen'),
+                    ),
+                  ],
+                ),
+              )
+            else
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: Text(
+                  'Gedrückt halten und ziehen (Mobilgerät) oder klicken und ziehen (Web) zum Auswählen eines Datumsbereichs',
+                  style: TextStyle(
+                    color: Theme.of(context).textTheme.bodySmall?.color,
+                    fontSize: 12,
+                    fontStyle: FontStyle.italic,
+                  ),
+                ),
+              ),
             Row(
               children: List.generate(7, (index) {
                 final day = DateFormat.E('de_DE').format(DateTime(
-                    2023, 1, 2 + index)); // Example year for weekday names
+                    2023, 1, 2 + index));
                 return Expanded(
                   child: Center(
                     child: Text(day),
@@ -1196,74 +1392,121 @@ class _Calendar extends StatelessWidget {
               }),
             ),
             const SizedBox(height: 10),
-            GridView.builder(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 7),
-              itemCount:
-                  _getDaysInMonth(selectedDate.year, selectedDate.month) +
-                      _getFirstDayOffset(selectedDate.year, selectedDate.month),
-              itemBuilder: (context, index) {
-                final firstDayOffset =
-                    _getFirstDayOffset(selectedDate.year, selectedDate.month);
-                if (index < firstDayOffset) {
-                  return const SizedBox.shrink();
+            // Grid-level Gesture-Handling für Mehrfachauswahl per Drag.
+            // Mobile: Long-Press + Ziehen → onLongPressStart/MoveUpdate/End
+            // Web/Desktop: Mausklick + Ziehen → Listener.onPointerDown/Move/Up
+            GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onLongPressStart: (details) {
+                if (!_isDragging) {
+                  _startDragAt(details.globalPosition, workdaysPerWeek);
                 }
+              },
+              onLongPressMoveUpdate: (details) {
+                _updateDragAt(details.globalPosition, workdaysPerWeek);
+              },
+              onLongPressEnd: (_) => _endDrag(workdaysPerWeek),
+              onLongPressCancel: () => _endDrag(workdaysPerWeek),
+              child: Listener(
+                behavior: HitTestBehavior.translucent,
+                onPointerDown: (event) {
+                  // Nur für Maus: Drag sofort starten (kein Long-Press nötig)
+                  if (event.kind == PointerDeviceKind.mouse && event.buttons == 1) {
+                    _startDragAt(event.position, workdaysPerWeek);
+                  }
+                },
+                onPointerMove: (event) {
+                  if (event.kind == PointerDeviceKind.mouse && _isDragging) {
+                    _updateDragAt(event.position, workdaysPerWeek);
+                  }
+                },
+                onPointerUp: (event) {
+                  if (event.kind == PointerDeviceKind.mouse && _isDragging) {
+                    _endDrag(workdaysPerWeek);
+                  }
+                },
+                child: GridView.builder(
+                  key: _gridKey,
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 7),
+                  itemCount:
+                      _getDaysInMonth(widget.selectedDate.year, widget.selectedDate.month) +
+                          _getFirstDayOffset(widget.selectedDate.year, widget.selectedDate.month),
+                  itemBuilder: (context, index) {
+                    final firstDayOffset =
+                        _getFirstDayOffset(widget.selectedDate.year, widget.selectedDate.month);
+                    if (index < firstDayOffset) {
+                      return const SizedBox.shrink();
+                    }
 
-                final day = index - firstDayOffset + 1;
-                final date =
-                    DateTime(selectedDate.year, selectedDate.month, day);
-                final isSelected = DateUtils.isSameDay(date, selectedDate);
-                final hasEntry = daysWithEntries?.contains(day) ?? false;
+                    final day = index - firstDayOffset + 1;
+                    final date =
+                        DateTime(widget.selectedDate.year, widget.selectedDate.month, day);
+                    final isSelected = DateUtils.isSameDay(date, widget.selectedDate);
+                    final isMultiSelected = reportsState.selectedDates
+                        .contains(DateTime(date.year, date.month, date.day));
+                    final hasEntry = widget.daysWithEntries?.contains(day) ?? false;
+                    final isWorkday = _isWorkday(date, workdaysPerWeek);
 
-                Widget dayWidget = Center(
-                  child: Text(
-                    '$day',
-                    style: TextStyle(
-                      color: isSelected
-                          ? Colors.white
-                          : Theme.of(context).textTheme.bodyLarge?.color,
-                    ),
-                  ),
-                );
-
-                if (hasEntry) {
-                  dayWidget = Stack(
-                    alignment: Alignment.center,
-                    children: [
-                      dayWidget, // The day number text
-                      Positioned(
-                        bottom: 4,
-                        child: Container(
-                          width: 5,
-                          height: 5,
-                          decoration: BoxDecoration(
-                            color: isSelected
-                                ? Colors.white70
-                                : Theme.of(context).colorScheme.secondary,
-                            shape: BoxShape.circle,
-                          ),
+                    Widget dayWidget = Center(
+                      child: Text(
+                        '$day',
+                        style: TextStyle(
+                          color: isSelected || isMultiSelected
+                              ? Colors.white
+                              : (isWorkday ? Theme.of(context).textTheme.bodyLarge?.color : Colors.grey),
                         ),
                       ),
-                    ],
-                  );
-                }
+                    );
 
-                return InkWell(
-                  onTap: () => onDateSelected(date),
-                  child: Container(
-                    margin: const EdgeInsets.all(4),
-                    decoration: BoxDecoration(
-                      color: isSelected
-                          ? Theme.of(context).primaryColor
-                          : Colors.transparent,
-                      shape: BoxShape.circle,
-                    ),
-                    child: dayWidget,
-                  ),
-                );
-              },
+                    if (hasEntry) {
+                      dayWidget = Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          dayWidget,
+                          Positioned(
+                            bottom: 4,
+                            child: Container(
+                              width: 5,
+                              height: 5,
+                              decoration: BoxDecoration(
+                                color: isSelected || isMultiSelected
+                                    ? Colors.white70
+                                    : Theme.of(context).colorScheme.secondary,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    }
+
+                    return GestureDetector(
+                      onTap: () => widget.onDateSelected(date),
+                      child: Container(
+                        margin: const EdgeInsets.all(4),
+                        decoration: BoxDecoration(
+                          color: isMultiSelected
+                              ? Theme.of(context).colorScheme.secondary
+                              : isSelected
+                                  ? Theme.of(context).primaryColor
+                                  : Colors.transparent,
+                          shape: BoxShape.circle,
+                          border: isMultiSelected
+                              ? Border.all(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  width: 2,
+                                )
+                              : null,
+                        ),
+                        child: dayWidget,
+                      ),
+                    );
+                  },
+                ),
+              ),
             )
           ],
         ),
@@ -1413,59 +1656,49 @@ class _DayEntriesBottomSheetState extends ConsumerState<DayEntriesBottomSheet> {
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           const Text('Keine Einträge für diesen Tag.'),
-                          Builder(builder: (context) {
-                            final today = DateUtils.dateOnly(DateTime.now());
-                            final sheetDateOnly =
-                                DateUtils.dateOnly(widget.date);
-
-                            if (sheetDateOnly.isBefore(today)) {
-                              return Padding(
-                                padding: const EdgeInsets.only(top: 16.0),
-                                child: Column(
-                                  children: [
-                                    SizedBox(
-                                      width: 280,
-                                      child: ElevatedButton.icon(
-                                        onPressed: () {
-                                          final newEntry = WorkEntryEntity(
-                                            id: DateFormat('yyyy-MM-dd')
-                                                .format(widget.date),
-                                            date: widget.date,
-                                            workStart: null,
-                                            workEnd: null,
-                                            breaks: [],
-                                            isManuallyEntered: true,
-                                            description: null,
-                                            manualOvertime: null,
-                                          );
-                                          _openEdit(newEntry);
-                                        },
-                                        icon: const Icon(Icons.add),
-                                        label: const Text('Eintrag hinzufügen'),
-                                      ),
-                                    ),
-                                    const SizedBox(height: 12),
-                                    SizedBox(
-                                      width: 280,
-                                      child: ElevatedButton.icon(
-                                        onPressed: () => _handleQuickEntry(
-                                            context, ref, widget.date),
-                                        icon: const Icon(Icons.flash_on),
-                                        label: const Text(
-                                            'Schnell-Eintrag (Urlaub, Krank...)'),
-                                        style: ElevatedButton.styleFrom(
-                                          backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-                                          foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
-                                        ),
-                                      ),
-                                    ),
-                                  ],
+                          Padding(
+                            padding: const EdgeInsets.only(top: 16.0),
+                            child: Column(
+                              children: [
+                                SizedBox(
+                                  width: 280,
+                                  child: ElevatedButton.icon(
+                                    onPressed: () {
+                                      final newEntry = WorkEntryEntity(
+                                        id: DateFormat('yyyy-MM-dd')
+                                            .format(widget.date),
+                                        date: widget.date,
+                                        workStart: null,
+                                        workEnd: null,
+                                        breaks: [],
+                                        isManuallyEntered: true,
+                                        description: null,
+                                        manualOvertime: null,
+                                      );
+                                      _openEdit(newEntry);
+                                    },
+                                    icon: const Icon(Icons.add),
+                                    label: const Text('Eintrag hinzufügen'),
+                                  ),
                                 ),
-                              );
-                            } else {
-                              return const SizedBox.shrink();
-                            }
-                          }),
+                                const SizedBox(height: 12),
+                                SizedBox(
+                                  width: 280,
+                                  child: ElevatedButton.icon(
+                                    onPressed: () => _handleQuickEntry(
+                                        context, ref, widget.date),
+                                    icon: const Icon(Icons.flash_on),
+                                    label: const Text(
+                                        'Schnell-Eintrag (Urlaub, Krank...)'),
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+                                      foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
                         ],
                       ),
                     ),
@@ -1600,5 +1833,50 @@ String _getWorkEntryTypeLabel(WorkEntryType type) {
       return 'Feiertag';
     case WorkEntryType.work:
       return 'Arbeit';
+  }
+}
+
+Future<void> _handleBatchQuickEntry(
+  BuildContext context,
+  WidgetRef ref,
+  ReportsState reportsState,
+  ReportsViewModel reportsNotifier,
+) async {
+  final settingsState = ref.read(settingsViewModelProvider).asData?.value;
+  Duration? dailyTarget;
+  if (settingsState != null) {
+    dailyTarget = Duration(
+      minutes: ((settingsState.settings.weeklyTargetHours /
+                  settingsState.settings.workdaysPerWeek) *
+              60)
+          .round(),
+    );
+  }
+
+  final result = await showDialog<Map<String, dynamic>>(
+    context: context,
+    builder: (BuildContext dialogContext) {
+      return BatchQuickEntryDialog(
+        dates: List<DateTime>.from(reportsState.selectedDates)..sort(),
+        dailyTarget: dailyTarget,
+      );
+    },
+  );
+
+  if (result != null) {
+    final count = reportsState.selectedDates.length;
+    await reportsNotifier.saveBatchWorkEntries(
+      List<DateTime>.from(reportsState.selectedDates),
+      result['type'] as WorkEntryType,
+      result['startTime'] as TimeOfDay?,
+      result['endTime'] as TimeOfDay?,
+    );
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Schnell-Einträge für $count Tage erstellt'),
+        ),
+      );
+    }
   }
 }

--- a/lib/presentation/state/reports_state.dart
+++ b/lib/presentation/state/reports_state.dart
@@ -17,6 +17,9 @@ class ReportsState extends Equatable {
   final DailyReportState dailyReportState;
   final WeeklyReportState weeklyReportState;
   final MonthlyReportState monthlyReportState;
+  // Multi-Select Fields
+  final Set<DateTime> selectedDates;
+  final bool multiSelectMode;
 
   const ReportsState({
     this.isLoading = false,
@@ -28,6 +31,8 @@ class ReportsState extends Equatable {
     this.dailyReportState = DailyReportState.initial,
     this.weeklyReportState = WeeklyReportState.initial,
     this.monthlyReportState = MonthlyReportState.initial,
+    this.selectedDates = const {},
+    this.multiSelectMode = false,
   });
 
   factory ReportsState.initial() {
@@ -51,6 +56,8 @@ class ReportsState extends Equatable {
     DailyReportState? dailyReportState,
     WeeklyReportState? weeklyReportState,
     MonthlyReportState? monthlyReportState,
+    Set<DateTime>? selectedDates,
+    bool? multiSelectMode,
   }) {
     return ReportsState(
       isLoading: isLoading ?? this.isLoading,
@@ -62,6 +69,8 @@ class ReportsState extends Equatable {
       dailyReportState: dailyReportState ?? this.dailyReportState,
       weeklyReportState: weeklyReportState ?? this.weeklyReportState,
       monthlyReportState: monthlyReportState ?? this.monthlyReportState,
+      selectedDates: selectedDates ?? this.selectedDates,
+      multiSelectMode: multiSelectMode ?? this.multiSelectMode,
     );
   }
 
@@ -76,6 +85,8 @@ class ReportsState extends Equatable {
         dailyReportState,
         weeklyReportState,
         monthlyReportState,
+        selectedDates,
+        multiSelectMode,
       ];
 }
 

--- a/lib/presentation/view_models/dashboard_view_model.dart
+++ b/lib/presentation/view_models/dashboard_view_model.dart
@@ -336,14 +336,14 @@ class DashboardViewModel extends Notifier<DashboardState> {
       updatedEntry = state.workEntry.copyWith(workEnd: now);
       logger.i('[Dashboard] Timer gestoppt um $now');
 
-      // Berechne automatische Pausen beim Beenden (nur wenn keine Pause läuft)
+      // Berechne automatische Pausen beim Beenden (nur wenn keine Pause läuft und Typ Arbeit ist)
       final hasRunningBreak = updatedEntry.breaks.any((b) => b.end == null);
-      if (!hasRunningBreak) {
+      if (!hasRunningBreak && updatedEntry.type == WorkEntryType.work) {
         logger.i('[Dashboard] Berechne automatische Pausen...');
         updatedEntry = BreakCalculatorService.calculateAndApplyBreaks(updatedEntry);
         logger.i('[Dashboard] Automatische Pausen berechnet: ${updatedEntry.breaks.length} Pausen');
       } else {
-        logger.i('[Dashboard] Automatische Pausen übersprungen: Pause läuft noch');
+        logger.i('[Dashboard] Automatische Pausen übersprungen: Pause läuft noch oder Sonder-Eintrag');
       }
     } else {
       // Arbeit wurde bereits beendet - Benutzer muss entscheiden
@@ -460,8 +460,9 @@ class DashboardViewModel extends Notifier<DashboardState> {
     // Berechne automatische Pausen nur wenn:
     // 1. Start UND End vorhanden sind
     // 2. Keine laufende Pause existiert
+    // 3. Eintrag ist vom Typ Arbeit (nicht Urlaub/Krank/Feiertag)
     final hasRunningBreak = updatedEntry.breaks.any((b) => b.end == null);
-    if (updatedEntry.workStart != null && updatedEntry.workEnd != null && !hasRunningBreak) {
+    if (updatedEntry.workStart != null && updatedEntry.workEnd != null && !hasRunningBreak && updatedEntry.type == WorkEntryType.work) {
       logger.i('[Dashboard] Berechne automatische Pausen...');
       updatedEntry = BreakCalculatorService.calculateAndApplyBreaks(updatedEntry);
       logger.i('[Dashboard] Automatische Pausen berechnet: ${updatedEntry.breaks.length} Pausen');
@@ -481,8 +482,9 @@ class DashboardViewModel extends Notifier<DashboardState> {
     // Berechne automatische Pausen nur wenn:
     // 1. Start UND End vorhanden sind
     // 2. Keine laufende Pause existiert
+    // 3. Eintrag ist vom Typ Arbeit (nicht Urlaub/Krank/Feiertag)
     final hasRunningBreak = updatedEntry.breaks.any((b) => b.end == null);
-    if (updatedEntry.workStart != null && updatedEntry.workEnd != null && !hasRunningBreak) {
+    if (updatedEntry.workStart != null && updatedEntry.workEnd != null && !hasRunningBreak && updatedEntry.type == WorkEntryType.work) {
       logger.i('[Dashboard] Berechne automatische Pausen...');
       updatedEntry = BreakCalculatorService.calculateAndApplyBreaks(updatedEntry);
       logger.i('[Dashboard] Automatische Pausen berechnet: ${updatedEntry.breaks.length} Pausen');

--- a/lib/presentation/view_models/reports_view_model.dart
+++ b/lib/presentation/view_models/reports_view_model.dart
@@ -1,7 +1,9 @@
 import 'dart:math';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
+import 'package:intl/intl.dart';
 
 import '../../core/providers/providers.dart' as core_providers;
 import '../../domain/entities/work_entry_entity.dart';
@@ -176,6 +178,11 @@ class ReportsViewModel extends Notifier<ReportsState> {
   }
 
   WorkEntryEntity applyBreakCalculation(WorkEntryEntity entry) {
+    // Keine Pausenberechnung für Urlaub, Krank oder Feiertag —
+    // diese Eintragstypen erfüllen das Soll automatisch ohne Pausenabzug.
+    if (entry.type != WorkEntryType.work) {
+      return entry;
+    }
     if (entry.workStart != null && entry.workEnd != null) {
       return BreakCalculatorService.calculateAndApplyBreaks(entry);
     }
@@ -354,4 +361,77 @@ class ReportsViewModel extends Notifier<ReportsState> {
       avgWorkDurationPerWeek: avgWorkDurationPerWeek,
     );
   }
+
+  // Multi-Select Methods (Range Selection via Drag)
+  void toggleMultiSelectMode() {
+    state = state.copyWith(multiSelectMode: !state.multiSelectMode);
+    if (!state.multiSelectMode) {
+      clearDateSelection();
+    }
+  }
+
+  void addDateToSelection(DateTime date) {
+    final dateOnly = DateTime(date.year, date.month, date.day);
+    final newSelectedDates = Set<DateTime>.from(state.selectedDates);
+    newSelectedDates.add(dateOnly);
+    state = state.copyWith(selectedDates: newSelectedDates);
+  }
+
+  void removeDateFromSelection(DateTime date) {
+    final dateOnly = DateTime(date.year, date.month, date.day);
+    final newSelectedDates = Set<DateTime>.from(state.selectedDates);
+    newSelectedDates.remove(dateOnly);
+    state = state.copyWith(selectedDates: newSelectedDates);
+  }
+
+  void toggleDateSelection(DateTime date) {
+    final dateOnly = DateTime(date.year, date.month, date.day);
+    if (state.selectedDates.contains(dateOnly)) {
+      removeDateFromSelection(dateOnly);
+    } else {
+      addDateToSelection(dateOnly);
+    }
+  }
+
+  void clearDateSelection() {
+    state = state.copyWith(selectedDates: const {});
+  }
+
+  Future<void> saveBatchWorkEntries(
+    List<DateTime> dates,
+    WorkEntryType type,
+    TimeOfDay? startTime,
+    TimeOfDay? endTime,
+  ) async {
+    state = state.copyWith(isLoading: true);
+    try {
+      final workRepository = ref.read(core_providers.workRepositoryProvider);
+
+      for (final date in dates) {
+        final entry = WorkEntryEntity(
+          id: DateFormat('yyyy-MM-dd').format(date),
+          date: date,
+          type: type,
+          isManuallyEntered: true,
+          workStart: startTime != null
+              ? DateTime(date.year, date.month, date.day, startTime.hour, startTime.minute)
+              : null,
+          workEnd: endTime != null
+              ? DateTime(date.year, date.month, date.day, endTime.hour, endTime.minute)
+              : null,
+        );
+        await workRepository.saveWorkEntry(entry);
+      }
+
+      // Clear selection, reset multi-select mode and reload data
+      final selectedDate = state.selectedDay ?? DateTime.now();
+      clearDateSelection();
+      state = state.copyWith(multiSelectMode: false);
+      await _loadWorkEntriesForMonth(selectedDate.year, selectedDate.month);
+    } catch (e, stackTrace) {
+      logger.e('Fehler beim Speichern von Batch-Einträgen: $e', stackTrace: stackTrace);
+      state = state.copyWith(isLoading: false);
+    }
+  }
 }
+

--- a/lib/presentation/widgets/batch_quick_entry_dialog.dart
+++ b/lib/presentation/widgets/batch_quick_entry_dialog.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../domain/entities/work_entry_entity.dart';
+
+class BatchQuickEntryDialog extends StatefulWidget {
+  final List<DateTime> dates;
+  final Duration? dailyTarget;
+
+  const BatchQuickEntryDialog({
+    super.key,
+    required this.dates,
+    this.dailyTarget,
+  });
+
+  @override
+  State<BatchQuickEntryDialog> createState() => _BatchQuickEntryDialogState();
+}
+
+class _BatchQuickEntryDialogState extends State<BatchQuickEntryDialog> {
+  WorkEntryType _selectedType = WorkEntryType.vacation;
+  TimeOfDay? _startTime;
+  TimeOfDay? _endTime;
+
+  @override
+  void initState() {
+    super.initState();
+    _setTimesBasedOnTarget();
+  }
+
+  void _setTimesBasedOnTarget() {
+    setState(() {
+      _startTime = const TimeOfDay(hour: 8, minute: 0);
+      if (widget.dailyTarget != null) {
+        final startDateTime = DateTime(2000, 1, 1, 8, 0);
+        final endDateTime = startDateTime.add(widget.dailyTarget!);
+        _endTime = TimeOfDay.fromDateTime(endDateTime);
+      } else {
+        _endTime = const TimeOfDay(hour: 16, minute: 0);
+      }
+    });
+  }
+
+  String _getWorkEntryTypeLabel(WorkEntryType type) {
+    switch (type) {
+      case WorkEntryType.vacation:
+        return '🏖️ Urlaub';
+      case WorkEntryType.sick:
+        return '🤒 Krankheit';
+      case WorkEntryType.holiday:
+        return '📅 Feiertag';
+      case WorkEntryType.work:
+        return '💼 Arbeit';
+    }
+  }
+
+  String _formatDateRange() {
+    if (widget.dates.isEmpty) return '';
+
+    final sortedDates = List<DateTime>.from(widget.dates)..sort();
+    final firstDate = sortedDates.first;
+    final lastDate = sortedDates.last;
+
+    final formatter = DateFormat.yMMMMd('de_DE');
+    if (firstDate.year == lastDate.year &&
+        firstDate.month == lastDate.month &&
+        firstDate.day == lastDate.day) {
+      return formatter.format(firstDate);
+    }
+
+    return '${formatter.format(firstDate)} - ${formatter.format(lastDate)}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Schnell-Eintrag für ${widget.dates.length} Tage'),
+          const SizedBox(height: 4),
+          Text(
+            _formatDateRange(),
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          DropdownButtonFormField<WorkEntryType>(
+            initialValue: _selectedType,
+            decoration: const InputDecoration(labelText: 'Typ'),
+            items: [
+              WorkEntryType.vacation,
+              WorkEntryType.sick,
+              WorkEntryType.holiday,
+            ].map((type) {
+              return DropdownMenuItem(
+                value: type,
+                child: Text(_getWorkEntryTypeLabel(type)),
+              );
+            }).toList(),
+            onChanged: (value) {
+              if (value != null) {
+                setState(() {
+                  _selectedType = value;
+                });
+                _setTimesBasedOnTarget();
+              }
+            },
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('Abbrechen'),
+        ),
+        FilledButton(
+          onPressed: () {
+            // Return the selected type and times
+            Navigator.pop(context, {
+              'type': _selectedType,
+              'startTime': _startTime,
+              'endTime': _endTime,
+            });
+          },
+          child: const Text('Speichern'),
+        ),
+      ],
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.22.1
+version: 0.23.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'

--- a/test/presentation/view_models/reports_view_model_test.dart
+++ b/test/presentation/view_models/reports_view_model_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
@@ -48,7 +49,7 @@ void main() {
           .thenAnswer((_) async => []);
 
       // Act
-      final viewModel = container.read(reportsViewModelProvider.notifier);
+      container.read(reportsViewModelProvider.notifier);
       // init is called in build via microtask, so we wait for pump
       await Future.delayed(Duration.zero); 
 
@@ -262,6 +263,115 @@ void main() {
       // Mo-Fr sollten reguläres Soll haben
       final mondayTarget = viewModel.getEffectiveDailyTargetForDate(DateTime(2023, 10, 23));
       expect(mondayTarget, const Duration(hours: 8));
+    });
+
+    group('Multi-Select Mode', () {
+      test('toggleMultiSelectMode should toggle the mode and clear selection', () async {
+        final now = DateTime.now();
+        when(mockWorkRepository.getWorkEntriesForMonth(now.year, now.month))
+            .thenAnswer((_) async => []);
+
+        final viewModel = container.read(reportsViewModelProvider.notifier);
+        await Future.delayed(Duration.zero);
+
+        expect(viewModel.state.multiSelectMode, false);
+        expect(viewModel.state.selectedDates, isEmpty);
+
+        viewModel.toggleMultiSelectMode();
+        expect(viewModel.state.multiSelectMode, true);
+
+        viewModel.toggleMultiSelectMode();
+        expect(viewModel.state.multiSelectMode, false);
+      });
+
+      test('addDateToSelection should add past and future dates', () async {
+        final now = DateTime.now();
+        when(mockWorkRepository.getWorkEntriesForMonth(now.year, now.month))
+            .thenAnswer((_) async => []);
+
+        final viewModel = container.read(reportsViewModelProvider.notifier);
+        await Future.delayed(Duration.zero);
+
+        final pastDate = DateTime.now().subtract(const Duration(days: 5));
+        final futureDate = DateTime.now().add(const Duration(days: 5));
+
+        viewModel.addDateToSelection(pastDate);
+        expect(viewModel.state.selectedDates.length, 1);
+
+        viewModel.addDateToSelection(futureDate);
+        expect(viewModel.state.selectedDates.length, 2); // Future dates are now allowed
+      });
+
+      test('toggleDateSelection should add/remove dates', () async {
+        final now = DateTime.now();
+        when(mockWorkRepository.getWorkEntriesForMonth(now.year, now.month))
+            .thenAnswer((_) async => []);
+
+        final viewModel = container.read(reportsViewModelProvider.notifier);
+        await Future.delayed(Duration.zero);
+
+        final testDate = DateTime.now().subtract(const Duration(days: 3));
+
+        viewModel.toggleDateSelection(testDate);
+        expect(viewModel.state.selectedDates, contains(DateTime(testDate.year, testDate.month, testDate.day)));
+
+        viewModel.toggleDateSelection(testDate);
+        expect(viewModel.state.selectedDates, isEmpty);
+      });
+
+      test('clearDateSelection should empty selected dates', () async {
+        final now = DateTime.now();
+        when(mockWorkRepository.getWorkEntriesForMonth(now.year, now.month))
+            .thenAnswer((_) async => []);
+
+        final viewModel = container.read(reportsViewModelProvider.notifier);
+        await Future.delayed(Duration.zero);
+
+        final date1 = DateTime.now().subtract(const Duration(days: 1));
+        final date2 = DateTime.now().subtract(const Duration(days: 2));
+
+        viewModel.addDateToSelection(date1);
+        viewModel.addDateToSelection(date2);
+        expect(viewModel.state.selectedDates.length, 2);
+
+        viewModel.clearDateSelection();
+        expect(viewModel.state.selectedDates, isEmpty);
+      });
+
+      test('saveBatchWorkEntries should create entries for all selected dates', () async {
+        final now = DateTime.now();
+        when(mockWorkRepository.getWorkEntriesForMonth(now.year, now.month))
+            .thenAnswer((_) async => []);
+
+        when(mockWorkRepository.saveWorkEntry(any))
+            .thenAnswer((_) async => {});
+
+        final viewModel = container.read(reportsViewModelProvider.notifier);
+        await Future.delayed(Duration.zero);
+
+        final dates = [
+          DateTime.now().subtract(const Duration(days: 3)),
+          DateTime.now().subtract(const Duration(days: 2)),
+          DateTime.now().subtract(const Duration(days: 1)),
+        ];
+
+        viewModel.toggleMultiSelectMode();
+        for (final date in dates) {
+          viewModel.addDateToSelection(date);
+        }
+
+        await viewModel.saveBatchWorkEntries(
+          dates,
+          WorkEntryType.vacation,
+          TimeOfDay(hour: 8, minute: 0),
+          TimeOfDay(hour: 16, minute: 0),
+        );
+
+        // Verify that saveWorkEntry was called for each date
+        verify(mockWorkRepository.saveWorkEntry(any)).called(3);
+        expect(viewModel.state.selectedDates, isEmpty);
+        expect(viewModel.state.multiSelectMode, false);
+      });
     });
   });
 }


### PR DESCRIPTION
Dieses PR implementiert die Mehrfach-Tagesauswahl per Drag für Schnell-Einträge (Urlaub, Krank, Feiertag) und behebt mehrere Fehler bei der Stundenberechnung für Sonder-Eintragstypen.

 ---
Neue Features

Kalender: Mehrfach-Auswahl per Drag
- Mobile: Tag gedrückt halten und ziehen → Datumsbereich wird ausgewählt
- Web/Desktop: Mausklick und ziehen → Datumsbereich wird ausgewählt
- Es werden automatisch nur konfigurierte Arbeitstage (Mo–Fr) selektiert
- Ausgewählte Tage werden visuell hervorgehoben; Auswahl kann mit „Zurücksetzen" geleert werden

Schnell-Eintrag für mehrere Tage gleichzeitig
- Neuer BatchQuickEntryDialog für die Erfassung von Urlaub/Krank/Feiertag über mehrere Tage auf einmal
- Der „Schnell-Eintrag"-Button ist nun smart: bei aktiver Mehrfachauswahl öffnet er den Batch-Dialog, ansonsten den Einzel-Tag-Dialog
- Schnell-Einträge sind jetzt auch für zukünftige Tage möglich

  ---
Bug Fixes

Falsche Überstunden-Berechnung bei Urlaub/Krank (lokal & Firestore)

Problem: Urlaub/Krank-Einträge zeigten fälschlicherweise −00:30 Überstunden statt 0:00.

Ursachen & Fixes:

1. Lokale Speicherung: LocalWorkRepositoryImpl._toLocalJson() hat das type-Feld nicht serialisiert. Einträge wurden daher immer als WorkEntryType.work geladen.
2. DashboardViewModel (Firestore): BreakCalculatorService.calculateAndApplyBreaks() wurde ohne Type-Check aufgerufen – auch bei Urlaubs-Einträgen. Die berechneten Pausen wurden dann in Firestore gespeichert, was die Anzeige
   nachhaltig verfälschte.
3. ReportsViewModel: applyBreakCalculation() berechnete Pausen unabhängig vom Eintragstyp. Jetzt wird für alle Nicht-Arbeits-Typen (Urlaub, Krank, Feiertag) frühzeitig zurückgegeben.

close #116