### PR TITLE
Premium-Screen-Absturz durch fehlerhafte RevenueCat-Integration beheben

### DIFF
--- a/lib/data/repositories/auth_repository_impl.dart
+++ b/lib/data/repositories/auth_repository_impl.dart
@@ -13,24 +13,31 @@ class AuthRepositoryImpl implements AuthRepository {
   AuthRepositoryImpl(this._dataSource);
 
   /// Implementiert den Stream, der auf An- und Abmeldeereignisse lauscht.
+  static const _rcAndroidKey = String.fromEnvironment('RC_ANDROID_KEY');
+  static const _rcIosKey = String.fromEnvironment('RC_IOS_KEY');
+  static bool get _isRcInitialized =>
+      !kIsWeb && (_rcAndroidKey.isNotEmpty || _rcIosKey.isNotEmpty);
+
   @override
   Stream<UserEntity?> get authStateChanges {
-    // Rufe den Stream der Datenquelle ab, der Firebase-Benutzerobjekte liefert.
-    return _dataSource.authStateChanges.map((firebaseUser) {
-      
-      // RevenueCat Synchronisation (nur Mobile)
-      if (!kIsWeb) {
+    return _dataSource.authStateChanges.asyncMap((firebaseUser) async {
+      // RevenueCat Synchronisation (nur Mobile, nur wenn RC initialisiert)
+      if (_isRcInitialized) {
         if (firebaseUser != null) {
-          // User hat sich eingeloggt oder App wurde mit eingeloggtem User gestartet
-          Purchases.logIn(firebaseUser.uid);
+          try {
+            await Purchases.logIn(firebaseUser.uid);
+          } catch (_) {
+            // Fehler ignorieren – kein gültiger Key oder Netzwerkproblem
+          }
         } else {
-          // User hat sich ausgeloggt
-          Purchases.logOut();
+          try {
+            await Purchases.logOut();
+          } catch (_) {
+            // Wird geworfen wenn der RC-User anonym ist – sicher ignorieren
+          }
         }
       }
 
-      // Wandle das Firebase-Benutzerobjekt in unsere eigene UserEntity um.
-      // Wenn der Firebase-Benutzer null ist (abgemeldet), gib auch null zurück.
       return firebaseUser != null
           ? _mapFirebaseUserToEntity(firebaseUser)
           : null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,21 +59,22 @@ Future<void> main() async {
   // ohne gültigen Web-Billing-Key sonst zu einem Absturz führt.
   if (!kIsWeb) {
     await Purchases.setLogLevel(LogLevel.debug);
-    PurchasesConfiguration configuration;
-    
-    // Lese Keys aus Environment Variables (via --dart-define)
-    const rcAndroidKey = String.fromEnvironment('RC_ANDROID_KEY', defaultValue: 'goog_api_key_placeholder');
-    const rcIosKey = String.fromEnvironment('RC_IOS_KEY', defaultValue: 'appl_api_key_placeholder');
 
-    if (Platform.isAndroid) {
-      configuration = PurchasesConfiguration(rcAndroidKey);
-    } else if (Platform.isIOS) {
-      configuration = PurchasesConfiguration(rcIosKey);
+    // Lese Keys aus Environment Variables (via --dart-define)
+    const rcAndroidKey = String.fromEnvironment('RC_ANDROID_KEY');
+    const rcIosKey = String.fromEnvironment('RC_IOS_KEY');
+
+    final String? activeKey = Platform.isAndroid
+        ? (rcAndroidKey.isEmpty ? null : rcAndroidKey)
+        : Platform.isIOS
+            ? (rcIosKey.isEmpty ? null : rcIosKey)
+            : null;
+
+    if (activeKey != null) {
+      await Purchases.configure(PurchasesConfiguration(activeKey));
     } else {
-      // Fallback für andere Plattformen, falls nötig
-      configuration = PurchasesConfiguration("other_platform_key_placeholder");
+      logger.w('RevenueCat nicht initialisiert – kein API-Key via --dart-define übergeben.');
     }
-    await Purchases.configure(configuration);
   }
 
   // Der Site Key wird sicher via --dart-define=RECAPTCHA_SITE_KEY=your_key beim Build injiziert

--- a/lib/presentation/screens/reports_page.dart
+++ b/lib/presentation/screens/reports_page.dart
@@ -33,19 +33,35 @@ class PendingTabIndexNotifier extends Notifier<int?> {
 }
 
 /// Zeigt die RevenueCat Paywall in einem Fullscreen-Modal an.
+const _rcAndroidKey = String.fromEnvironment('RC_ANDROID_KEY');
+
 void _showPaywall(BuildContext context) {
+  // Im lokalen Test ohne gültigen RC-Key kein Paywall öffnen
+  if (_rcAndroidKey.isEmpty) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text(
+          'Paywall nicht verfügbar – App ohne RC_ANDROID_KEY gestartet.',
+        ),
+      ),
+    );
+    return;
+  }
+
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
     useSafeArea: true,
     backgroundColor: Colors.transparent,
-    builder: (context) => Container(
+    builder: (ctx) => Container(
       decoration: BoxDecoration(
-        color: Theme.of(context).scaffoldBackgroundColor,
+        color: Theme.of(ctx).scaffoldBackgroundColor,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
       ),
       child: PaywallView(
-        onDismiss: () => Navigator.of(context).pop(),
+        onDismiss: () {
+          if (Navigator.of(ctx).canPop()) Navigator.of(ctx).pop();
+        },
       ),
     ),
   );
@@ -612,7 +628,9 @@ class WeeklyReportView extends ConsumerWidget {
         featureTitle: 'Wochenberichte',
         featureText:
             'Behalte den vollen Überblick über deine wöchentlichen Überstunden und Arbeitsmuster.',
-        onUpgrade: kIsWeb ? null : () => _showPaywall(context),
+        onUpgrade: kIsWeb ? null : () {
+          if (context.mounted) _showPaywall(context);
+        },
         child: const _WeeklyReportPlaceholder(),
       );
     }
@@ -872,7 +890,9 @@ class MonthlyReportView extends ConsumerWidget {
         featureTitle: 'Monatsberichte',
         featureText:
             'Detaillierte Monatsanalysen mit Überstunden-Tracking und Urlaubsübersicht.',
-        onUpgrade: kIsWeb ? null : () => _showPaywall(context),
+        onUpgrade: kIsWeb ? null : () {
+          if (context.mounted) _showPaywall(context);
+        },
         child: const _MonthlyReportPlaceholder(),
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.24.0
+version: 0.24.1
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Die App stürzte beim Navigieren auf dem Premium/Reports-Screen ab. Ursache war eine fehlerhafte RevenueCat-Integration, die in mehreren Schichten Fehler verursachte:

1. Root Cause: Purchases.logIn() / Purchases.logOut() wurden in einem synchronen map()-Stream aufgerufen, ohne Exception-Handling. Wenn RC-Fehler auftraten (ungültiger Key, anonymer User), propagierten diese unbehandelt durch
   den Stream und crashten die App.
2. Sekundär: RC wurde mit einem Placeholder-Key initialisiert, was alle API-Calls mit 401/Invalid-API-Key fehlschlagen ließ.
3. Tertiär: Im Paywall-Dialog fehlten context.mounted-Checks und ein canPop()-Guard.