### PR TITLE
feat(web): Android-Banner + Mobile Responsive + Firebase Login Fix

### DIFF
--- a/.github/workflows/deploy-angular.yml
+++ b/.github/workflows/deploy-angular.yml
@@ -44,23 +44,37 @@ jobs:
 
       - name: Inject environment.ts
         env:
-          RC_WEB_KEY: ${{ secrets.RC_WEB_KEY }}
+          FIREBASE_API_KEY:             ${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_AUTH_DOMAIN:         ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          FIREBASE_PROJECT_ID:          ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_STORAGE_BUCKET:      ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
+          FIREBASE_APP_ID:              ${{ secrets.FIREBASE_APP_ID }}
+          FIREBASE_MEASUREMENT_ID:      ${{ secrets.FIREBASE_MEASUREMENT_ID }}
+          RC_WEB_KEY:                   ${{ secrets.RC_WEB_KEY }}
         run: |
           cat > src/environments/environment.ts <<'ENVEOF'
           export const environment = {
             production: true,
             firebase: {
-              apiKey:            'AIzaSyAlBWIrPPlT8NaH2sWzrl3jsp_tVVM9KJM',
-              authDomain:        'worktime-56c7a.firebaseapp.com',
-              projectId:         'worktime-56c7a',
-              storageBucket:     'worktime-56c7a.firebasestorage.app',
-              messagingSenderId: '915742606352',
-              appId:             '1:915742606352:web:f94b1304e714d8ad21f695',
-              measurementId:     'G-YZSWN2Y84F',
+              apiKey:            'FIREBASE_API_KEY_PLACEHOLDER',
+              authDomain:        'FIREBASE_AUTH_DOMAIN_PLACEHOLDER',
+              projectId:         'FIREBASE_PROJECT_ID_PLACEHOLDER',
+              storageBucket:     'FIREBASE_STORAGE_BUCKET_PLACEHOLDER',
+              messagingSenderId: 'FIREBASE_MESSAGING_SENDER_ID_PLACEHOLDER',
+              appId:             'FIREBASE_APP_ID_PLACEHOLDER',
+              measurementId:     'FIREBASE_MEASUREMENT_ID_PLACEHOLDER',
             },
             rcWebApiKey: 'RC_KEY_PLACEHOLDER',
           };
           ENVEOF
+          sed -i "s|FIREBASE_API_KEY_PLACEHOLDER|${FIREBASE_API_KEY}|" src/environments/environment.ts
+          sed -i "s|FIREBASE_AUTH_DOMAIN_PLACEHOLDER|${FIREBASE_AUTH_DOMAIN}|" src/environments/environment.ts
+          sed -i "s|FIREBASE_PROJECT_ID_PLACEHOLDER|${FIREBASE_PROJECT_ID}|" src/environments/environment.ts
+          sed -i "s|FIREBASE_STORAGE_BUCKET_PLACEHOLDER|${FIREBASE_STORAGE_BUCKET}|" src/environments/environment.ts
+          sed -i "s|FIREBASE_MESSAGING_SENDER_ID_PLACEHOLDER|${FIREBASE_MESSAGING_SENDER_ID}|" src/environments/environment.ts
+          sed -i "s|FIREBASE_APP_ID_PLACEHOLDER|${FIREBASE_APP_ID}|" src/environments/environment.ts
+          sed -i "s|FIREBASE_MEASUREMENT_ID_PLACEHOLDER|${FIREBASE_MEASUREMENT_ID}|" src/environments/environment.ts
           sed -i "s|RC_KEY_PLACEHOLDER|${RC_WEB_KEY}|" src/environments/environment.ts
 
       - name: Build (production)

--- a/.github/workflows/deploy-angular.yml
+++ b/.github/workflows/deploy-angular.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           RC_WEB_KEY: ${{ secrets.RC_WEB_KEY }}
         run: |
-          cat > src/environments/environment.ts << EOF
+          cat > src/environments/environment.ts <<'ENVEOF'
           export const environment = {
             production: true,
             firebase: {
@@ -58,9 +58,10 @@ jobs:
               appId:             '1:915742606352:web:f94b1304e714d8ad21f695',
               measurementId:     'G-YZSWN2Y84F',
             },
-            rcWebApiKey: '${RC_WEB_KEY}',
+            rcWebApiKey: 'RC_KEY_PLACEHOLDER',
           };
-          EOF
+          ENVEOF
+          sed -i "s|RC_KEY_PLACEHOLDER|${RC_WEB_KEY}|" src/environments/environment.ts
 
       - name: Build (production)
         run: npm run build -- --configuration production

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -11,16 +11,9 @@
   "lang": "de",
   "icons": [
     {
-      "src": "icons/icon-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "icons/icon-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "src": "favicon.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon"
     }
   ],
   "categories": ["productivity", "business"],

--- a/web/src/app/app.html
+++ b/web/src/app/app.html
@@ -1,1 +1,4 @@
+@if (isAndroid()) {
+  <app-android-banner />
+}
 <router-outlet />

--- a/web/src/app/app.ts
+++ b/web/src/app/app.ts
@@ -1,16 +1,76 @@
-import { Component, effect, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { ThemeService } from './core/services/theme';
+
+const PLAY_STORE_URL = 'https://play.google.com/store/apps/details?id=app.work_time_manager';
+const DISMISSED_KEY  = 'android_banner_dismissed';
+
+// ── Android App Banner ────────────────────────────────────────────────────────
+
+@Component({
+  selector: 'app-android-banner',
+  imports: [MatButtonModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  styles: [`
+    .banner {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 16px;
+      background: var(--mat-sys-primary-container);
+      color: var(--mat-sys-on-primary-container);
+    }
+    .banner-icon { font-size: 28px; width: 28px; height: 28px; flex-shrink: 0; }
+    .banner-text { flex: 1; min-width: 0; }
+    .banner-title { font-size: 0.875rem; font-weight: 500; margin: 0; }
+    .banner-sub   { font-size: 0.75rem;  opacity: 0.8;     margin: 0; }
+  `],
+  template: `
+    @if (visible()) {
+      <div class="banner" role="banner" aria-label="Android-App verfügbar">
+        <mat-icon class="banner-icon" aria-hidden="true">android</mat-icon>
+        <div class="banner-text">
+          <p class="banner-title">Work Time Manager App</p>
+          <p class="banner-sub">Kostenlos im Google Play Store</p>
+        </div>
+        <a mat-flat-button [href]="playStoreUrl" target="_blank" rel="noopener"
+           aria-label="App im Play Store öffnen">
+          Öffnen
+        </a>
+        <button mat-icon-button (click)="dismiss()" aria-label="Banner schließen">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    }
+  `,
+})
+export class AndroidBannerComponent {
+  protected readonly playStoreUrl = PLAY_STORE_URL;
+  readonly visible = signal(!localStorage.getItem(DISMISSED_KEY));
+
+  dismiss(): void {
+    localStorage.setItem(DISMISSED_KEY, '1');
+    this.visible.set(false);
+  }
+}
+
+// ── App Root ──────────────────────────────────────────────────────────────────
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, AndroidBannerComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './app.html',
-  styleUrl: './app.scss',
+  styleUrl:    './app.scss',
 })
 export class App {
-  protected readonly title = signal('work-time-manager-web');
-  private  readonly theme  = inject(ThemeService);
+  private readonly theme = inject(ThemeService);
+
+  protected readonly isAndroid = signal(
+    typeof navigator !== 'undefined' && /Android/i.test(navigator.userAgent)
+  );
 
   constructor() {
     this.theme.applyStoredTheme();

--- a/web/src/app/features/dashboard/dashboard.scss
+++ b/web/src/app/features/dashboard/dashboard.scss
@@ -14,6 +14,10 @@
   padding: 24px;
   display: flex;
   justify-content: center;
+
+  @media (max-width: 600px) {
+    padding: 16px 12px;
+  }
 }
 
 .dashboard-content {
@@ -27,6 +31,10 @@
   @media (max-width: 900px) {
     grid-template-columns: 1fr;
     gap: 32px;
+  }
+
+  @media (max-width: 600px) {
+    gap: 16px;
   }
 }
 
@@ -42,6 +50,10 @@
 .timer-section {
   text-align: center;
   padding: 32px 0 16px;
+
+  @media (max-width: 600px) {
+    padding: 16px 0 8px;
+  }
 
   .timer-label {
     font-size: 0.875rem;
@@ -59,12 +71,20 @@
     line-height: 1;
     color: var(--mat-sys-on-surface);
     font-variant-numeric: tabular-nums;
+
+    @media (max-width: 600px) {
+      font-size: 42px;
+    }
   }
 
   .gross-time {
     font-size: 1rem;
     opacity: 0.65;
     margin: 12px 0 0;
+
+    @media (max-width: 600px) {
+      font-size: 0.875rem;
+    }
   }
 }
 

--- a/web/src/app/features/reports/reports.scss
+++ b/web/src/app/features/reports/reports.scss
@@ -40,6 +40,10 @@
   margin: 0 auto;
   width: 100%;
   box-sizing: border-box;
+
+  @media (max-width: 600px) {
+    padding: 16px 12px;
+  }
 }
 
 // ── Daily layout ───────────────────────────────────────────────────────────────
@@ -55,6 +59,11 @@
   @media (max-width: 900px) {
     flex-direction: column;
     gap: 24px;
+  }
+
+  @media (max-width: 600px) {
+    padding: 12px;
+    gap: 16px;
   }
 }
 

--- a/web/src/app/features/settings/settings.scss
+++ b/web/src/app/features/settings/settings.scss
@@ -11,6 +11,10 @@
   padding: 24px 16px;
   display: flex;
   justify-content: center;
+
+  @media (max-width: 600px) {
+    padding: 16px 8px;
+  }
 }
 
 .settings-content {


### PR DESCRIPTION
**Android-App-Banner**
Zeigt auf Android-Geräten automatisch einen dismissbaren Banner
mit Link zum Play Store. Einmalig schließbar (localStorage).

**Mobile Responsive**
Neuer 600px-Breakpoint in Dashboard, Reports und Settings:
- Timer-Schrift: 57px → 42px auf kleinen Screens
- Padding in allen drei Views reduziert

**Firebase Login Fix**
- Firebase-Config jetzt via GitHub Secrets (nicht mehr hardcoded)
- environment.ts Injektion auf quoted heredoc + sed umgestellt
- nginx läuft auf Port 8080 (Port 80 = Traefik-Entrypoint)
- Traefik Middleware eindeutig benannt (wtm-https-redirect)
- PWA-Icons 404 behoben