### PR TITLE
fix(web): robust environment injection in CI/CD

### DIFF
--- a/.github/workflows/deploy-angular.yml
+++ b/.github/workflows/deploy-angular.yml
@@ -42,6 +42,19 @@ jobs:
       - name: Install dependencies
         run: npm ci --legacy-peer-deps
 
+      - name: Verify Secrets
+        run: |
+          MISSING_SECRETS=()
+          [[ -z "${{ secrets.FIREBASE_API_KEY }}" ]] && MISSING_SECRETS+=("FIREBASE_API_KEY")
+          [[ -z "${{ secrets.FIREBASE_APP_ID }}" ]] && MISSING_SECRETS+=("FIREBASE_APP_ID")
+          [[ -z "${{ secrets.FIREBASE_PROJECT_ID }}" ]] && MISSING_SECRETS+=("FIREBASE_PROJECT_ID")
+          [[ -z "${{ secrets.RC_WEB_KEY }}" ]] && MISSING_SECRETS+=("RC_WEB_KEY")
+          
+          if [ ${#MISSING_SECRETS[@]} -ne 0 ]; then
+            echo "Error: The following secrets are missing: ${MISSING_SECRETS[*]}"
+            exit 1
+          fi
+
       - name: Inject environment.ts
         env:
           FIREBASE_API_KEY:             ${{ secrets.FIREBASE_API_KEY }}
@@ -53,32 +66,31 @@ jobs:
           FIREBASE_MEASUREMENT_ID:      ${{ secrets.FIREBASE_MEASUREMENT_ID }}
           RC_WEB_KEY:                   ${{ secrets.RC_WEB_KEY }}
         run: |
-          cat > src/environments/environment.ts <<'ENVEOF'
+          mkdir -p src/environments
+          cat > src/environments/environment.ts <<EOF
           export const environment = {
             production: true,
             firebase: {
-              apiKey:            'FIREBASE_API_KEY_PLACEHOLDER',
-              authDomain:        'FIREBASE_AUTH_DOMAIN_PLACEHOLDER',
-              projectId:         'FIREBASE_PROJECT_ID_PLACEHOLDER',
-              storageBucket:     'FIREBASE_STORAGE_BUCKET_PLACEHOLDER',
-              messagingSenderId: 'FIREBASE_MESSAGING_SENDER_ID_PLACEHOLDER',
-              appId:             'FIREBASE_APP_ID_PLACEHOLDER',
-              measurementId:     'FIREBASE_MEASUREMENT_ID_PLACEHOLDER',
+              apiKey:            '${FIREBASE_API_KEY}',
+              authDomain:        '${FIREBASE_AUTH_DOMAIN}',
+              projectId:         '${FIREBASE_PROJECT_ID}',
+              storageBucket:     '${FIREBASE_STORAGE_BUCKET}',
+              messagingSenderId: '${FIREBASE_MESSAGING_SENDER_ID}',
+              appId:             '${FIREBASE_APP_ID}',
+              measurementId:     '${FIREBASE_MEASUREMENT_ID}',
             },
-            rcWebApiKey: 'RC_KEY_PLACEHOLDER',
+            rcWebApiKey: '${RC_WEB_KEY}',
           };
-          ENVEOF
-          sed -i "s|FIREBASE_API_KEY_PLACEHOLDER|${FIREBASE_API_KEY}|" src/environments/environment.ts
-          sed -i "s|FIREBASE_AUTH_DOMAIN_PLACEHOLDER|${FIREBASE_AUTH_DOMAIN}|" src/environments/environment.ts
-          sed -i "s|FIREBASE_PROJECT_ID_PLACEHOLDER|${FIREBASE_PROJECT_ID}|" src/environments/environment.ts
-          sed -i "s|FIREBASE_STORAGE_BUCKET_PLACEHOLDER|${FIREBASE_STORAGE_BUCKET}|" src/environments/environment.ts
-          sed -i "s|FIREBASE_MESSAGING_SENDER_ID_PLACEHOLDER|${FIREBASE_MESSAGING_SENDER_ID}|" src/environments/environment.ts
-          sed -i "s|FIREBASE_APP_ID_PLACEHOLDER|${FIREBASE_APP_ID}|" src/environments/environment.ts
-          sed -i "s|FIREBASE_MEASUREMENT_ID_PLACEHOLDER|${FIREBASE_MEASUREMENT_ID}|" src/environments/environment.ts
-          sed -i "s|RC_KEY_PLACEHOLDER|${RC_WEB_KEY}|" src/environments/environment.ts
+          EOF
+          echo "environment.ts created successfully."
+          # Validierung (ohne Keys zu zeigen): Prüfen ob Platzhalter noch da sind
+          if grep -q "PLACEHOLDER" src/environments/environment.ts; then
+            echo "Error: Placeholders still present in environment.ts"
+            exit 1
+          fi
 
       - name: Build (production)
-        run: npm run build -- --configuration production
+        run: npm run build -- --configuration production --delete-output-path
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Replace 'sed' with direct shell expansion to avoid issues with special characters in secrets
- Add 'Verify Secrets' step to fail fast if required GitHub Secrets are missing
- Add validation check to ensure no placeholders remain in environment.ts
- Use '--delete-output-path' for clean production builds