### PR TITLE
fix(lint): alle flutter analyze Warnings bereinigt

### DIFF
--- a/mobile/lib/core/services/notification_service.dart
+++ b/mobile/lib/core/services/notification_service.dart
@@ -2,8 +2,6 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:flutter_work_time/core/utils/logger.dart';
 
-import '../../domain/repositories/work_repository.dart';
-
 class NotificationService {
   static final NotificationService _instance = NotificationService._internal();
   

--- a/mobile/lib/domain/repositories/settings_repository.dart
+++ b/mobile/lib/domain/repositories/settings_repository.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart' show ThemeMode;
 
-import '../entities/work_entry_entity.dart';
-
 /// Die Schnittstelle (der Vertrag) für den Zugriff auf lokale App-Einstellungen.
 ///
 /// Dieses Repository abstrahiert, wo und wie die Einstellungen gespeichert werden

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -3,7 +3,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_work_time/presentation/screens/home_screen.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,7 +16,6 @@ import 'dart:io' show Platform;
 
 import 'package:flutter_localizations/flutter_localizations.dart';
 
-import 'core/config/google_sign_in_config.dart';
 import 'core/providers/providers.dart';
 import 'core/services/notification_service.dart';
 import 'core/theme/app_theme.dart';

--- a/mobile/test/presentation/screens/reports_page_test.dart
+++ b/mobile/test/presentation/screens/reports_page_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';

--- a/mobile/test/presentation/view_models/dashboard_view_model_test.dart
+++ b/mobile/test/presentation/view_models/dashboard_view_model_test.dart
@@ -74,7 +74,7 @@ void main() {
       when(mockGetTodayWorkEntry()).thenAnswer((_) async => entry);
 
       // Act
-      final viewModel = container.read(dashboardViewModelProvider.notifier);
+      container.read(dashboardViewModelProvider.notifier);
       // Wait for init
       await Future.delayed(Duration.zero);
       
@@ -119,7 +119,7 @@ void main() {
 
       when(mockGetTodayWorkEntry()).thenAnswer((_) async => entry);
 
-      final viewModel = container.read(dashboardViewModelProvider.notifier);
+      container.read(dashboardViewModelProvider.notifier);
       await Future.delayed(Duration.zero);
       
       final state = container.read(dashboardViewModelProvider);
@@ -157,7 +157,7 @@ void main() {
       // Last update was yesterday (so it's fully initial)
       when(mockOvertimeRepository.getLastUpdateDate()).thenReturn(now.subtract(const Duration(days: 1)));
 
-      final viewModel = container.read(dashboardViewModelProvider.notifier);
+      container.read(dashboardViewModelProvider.notifier);
       await Future.delayed(Duration.zero);
       
       final state = container.read(dashboardViewModelProvider);

--- a/mobile/test/presentation/widgets/edit_break_modal_test.dart
+++ b/mobile/test/presentation/widgets/edit_break_modal_test.dart
@@ -9,11 +9,9 @@ import 'package:flutter_work_time/presentation/widgets/edit_break_modal.dart';
 
 void main() {
   group('EditBreakModal', () {
-    late DateTime testDate;
     late BreakEntity testBreak;
 
     setUp(() {
-      testDate = DateTime(2024, 1, 15);
       testBreak = BreakEntity(
         id: 'break-1',
         name: 'Mittagspause',


### PR DESCRIPTION
- notification_service.dart: unused import work_repository entfernt
- settings_repository.dart: unused import work_entry_entity entfernt
- main.dart: unused imports google_sign_in + google_sign_in_config entfernt
- reports_page_test.dart: unused import intl entfernt
- dashboard_view_model_test.dart: unused viewModel-Variablen entfernt (3x)
- edit_break_modal_test.dart: unused testDate-Variable entfernt