### PR TITLE
fix(overtime): Race Condition beim Laden der Überstunden aus Firebase…

### DIFF
--- a/mobile/lib/data/repositories/firebase_overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/firebase_overtime_repository_impl.dart
@@ -89,4 +89,10 @@ class FirebaseOvertimeRepositoryImpl implements OvertimeRepository {
     _cachedLastUpdate = lastUpdate;
     return lastUpdate;
   }
+
+  @override
+  Future<Duration> ensureOvertimeLoaded() => loadOvertimeAsync();
+
+  @override
+  Future<DateTime?> ensureLastUpdateLoaded() => loadLastUpdateAsync();
 }

--- a/mobile/lib/data/repositories/hybrid_overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/hybrid_overtime_repository_impl.dart
@@ -1,6 +1,5 @@
 import '../../domain/repositories/overtime_repository.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
-import 'firebase_overtime_repository_impl.dart';
 
 /// Hybrid Repository für Überstunden, das automatisch zwischen Firebase und Local wechselt.
 class HybridOvertimeRepositoryImpl implements OvertimeRepository {
@@ -59,26 +58,14 @@ class HybridOvertimeRepositoryImpl implements OvertimeRepository {
   /// Gibt das Firebase Repository zurück (für Sync-Operationen)
   OvertimeRepository get firebaseRepository => _firebaseRepository;
 
-  /// Lädt die Überstunden async von Firebase und cached sie.
-  /// Gibt den geladenen Wert zurück.
-  /// Bei Local-Repository wird einfach der aktuelle Wert zurückgegeben.
+  @override
   Future<Duration> ensureOvertimeLoaded() async {
-    if (isUsingFirebase && _firebaseRepository is FirebaseOvertimeRepositoryImpl) {
-      final firebaseRepo = _firebaseRepository as FirebaseOvertimeRepositoryImpl;
-      logger.i('[HybridOvertimeRepository] Lade Überstunden async von Firebase...');
-      final overtime = await firebaseRepo.loadOvertimeAsync();
-      logger.i('[HybridOvertimeRepository] Überstunden geladen: ${overtime.inMinutes} Min');
-      return overtime;
-    }
-    return _activeRepository.getOvertime();
+    logger.i('[HybridOvertimeRepository] ensureOvertimeLoaded (Firebase: $isUsingFirebase)');
+    final overtime = await _activeRepository.ensureOvertimeLoaded();
+    logger.i('[HybridOvertimeRepository] Überstunden geladen: ${overtime.inMinutes} Min');
+    return overtime;
   }
 
-  /// Lädt das letzte Update-Datum async von Firebase und cached es.
-  Future<DateTime?> ensureLastUpdateLoaded() async {
-    if (isUsingFirebase && _firebaseRepository is FirebaseOvertimeRepositoryImpl) {
-      final firebaseRepo = _firebaseRepository as FirebaseOvertimeRepositoryImpl;
-      return await firebaseRepo.loadLastUpdateAsync();
-    }
-    return _activeRepository.getLastUpdateDate();
-  }
+  @override
+  Future<DateTime?> ensureLastUpdateLoaded() => _activeRepository.ensureLastUpdateLoaded();
 }

--- a/mobile/lib/data/repositories/local_overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/local_overtime_repository_impl.dart
@@ -41,4 +41,10 @@ class LocalOvertimeRepositoryImpl implements OvertimeRepository {
   Future<void> saveLastUpdateDate(DateTime date) async {
     await _prefs.setString(_overtimeDateKey, date.toIso8601String());
   }
+
+  @override
+  Future<Duration> ensureOvertimeLoaded() async => getOvertime();
+
+  @override
+  Future<DateTime?> ensureLastUpdateLoaded() async => getLastUpdateDate();
 }

--- a/mobile/lib/data/repositories/overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/overtime_repository_impl.dart
@@ -43,4 +43,10 @@ class OvertimeRepositoryImpl implements OvertimeRepository {
   Future<void> saveLastUpdateDate(DateTime date) async {
     await _prefs.setString(_userDatePrefKey, date.toIso8601String());
   }
+
+  @override
+  Future<Duration> ensureOvertimeLoaded() async => getOvertime();
+
+  @override
+  Future<DateTime?> ensureLastUpdateLoaded() async => getLastUpdateDate();
 }

--- a/mobile/lib/domain/repositories/overtime_repository.dart
+++ b/mobile/lib/domain/repositories/overtime_repository.dart
@@ -1,15 +1,24 @@
 /// Das Repository für die Verwaltung des Überstundensaldos.
 /// Es entkoppelt die Anwendungslogik von der konkreten Datenspeicherung.
 abstract class OvertimeRepository {
-  /// Ruft den aktuellen Überstundensaldo ab.
+  /// Ruft den aktuellen Überstundensaldo ab (synchron, aus Cache).
   Duration getOvertime();
 
   /// Speichert den neuen Überstundensaldo.
   Future<void> saveOvertime(Duration overtime);
 
-  /// Ruft das Datum der letzten Überstunden-Aktualisierung ab.
+  /// Ruft das Datum der letzten Überstunden-Aktualisierung ab (synchron, aus Cache).
   DateTime? getLastUpdateDate();
 
   /// Speichert das Datum der letzten Überstunden-Aktualisierung.
   Future<void> saveLastUpdateDate(DateTime date);
+
+  /// Stellt sicher, dass der Überstundensaldo aus dem Backend geladen ist,
+  /// und gibt ihn zurück. Remote-Implementierungen überschreiben diese Methode
+  /// mit einem echten async-Abruf; lokale Implementierungen delegieren auf [getOvertime].
+  Future<Duration> ensureOvertimeLoaded() async => getOvertime();
+
+  /// Stellt sicher, dass das letzte Update-Datum aus dem Backend geladen ist.
+  /// Entspricht [ensureOvertimeLoaded] für das Update-Datum.
+  Future<DateTime?> ensureLastUpdateLoaded() async => getLastUpdateDate();
 }

--- a/mobile/lib/presentation/view_models/dashboard_view_model.dart
+++ b/mobile/lib/presentation/view_models/dashboard_view_model.dart
@@ -35,8 +35,9 @@ class DashboardViewModel extends Notifier<DashboardState> {
     final overtimeRepository = ref.read(overtimeRepositoryProvider);
 
     final workEntry = await getTodayWorkEntry.call();
-    final storedOvertime = overtimeRepository.getOvertime();
-    final lastUpdateDate = overtimeRepository.getLastUpdateDate();
+    // Async laden statt synchronem Cache-Zugriff (verhindert Race Condition bei Firebase-Login)
+    final storedOvertime = await overtimeRepository.ensureOvertimeLoaded();
+    final lastUpdateDate = await overtimeRepository.ensureLastUpdateLoaded();
 
     // Lade Wocheneinträge um zu prüfen ob heute ein Zusatztag ist
     await _loadWeekEntries(workEntry);

--- a/mobile/lib/presentation/view_models/settings_view_model.dart
+++ b/mobile/lib/presentation/view_models/settings_view_model.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/providers/providers.dart' as core_providers;
-import '../../data/repositories/hybrid_overtime_repository_impl.dart';
 import '../../domain/entities/settings_entity.dart';
 import '../../domain/repositories/settings_repository.dart';
 import '../state/settings_state.dart';
@@ -88,19 +87,8 @@ class SettingsViewModel extends Notifier<AsyncValue<SettingsState>> {
       final overtimeRepository = ref.read(core_providers.overtimeRepositoryProvider);
       final settingsRepository = ref.read(core_providers.settingsRepositoryProvider);
 
-      // Für Firebase: Stelle sicher, dass Überstunden async geladen werden
-      Duration overtimeBalance;
-      DateTime? lastOvertimeUpdate;
-
-      if (overtimeRepository is HybridOvertimeRepositoryImpl) {
-        overtimeBalance = await overtimeRepository.ensureOvertimeLoaded();
-        lastOvertimeUpdate = await overtimeRepository.ensureLastUpdateLoaded();
-      } else {
-        final getOvertime = ref.read(core_providers.getOvertimeUseCaseProvider);
-        final getLastUpdate = ref.read(core_providers.getLastOvertimeUpdateUseCaseProvider);
-        overtimeBalance = getOvertime.call();
-        lastOvertimeUpdate = getLastUpdate.call();
-      }
+      final overtimeBalance = await overtimeRepository.ensureOvertimeLoaded();
+      final lastOvertimeUpdate = await overtimeRepository.ensureLastUpdateLoaded();
       final weeklyTargetHours = settingsRepository.getTargetWeeklyHours();
       final workdaysPerWeek = settingsRepository.getWorkdaysPerWeek();
       final notificationsEnabled = settingsRepository.getNotificationsEnabled();

--- a/mobile/test/domain/usecases/overtime_usecases_test.mocks.dart
+++ b/mobile/test/domain/usecases/overtime_usecases_test.mocks.dart
@@ -77,4 +77,28 @@ class MockOvertimeRepository extends _i1.Mock
         returnValue: _i3.Future<void>.value(),
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
+
+  @override
+  _i3.Future<Duration> ensureOvertimeLoaded() => (super.noSuchMethod(
+        Invocation.method(
+          #ensureOvertimeLoaded,
+          [],
+        ),
+        returnValue: _i3.Future<Duration>.value(_FakeDuration_0(
+          this,
+          Invocation.method(
+            #ensureOvertimeLoaded,
+            [],
+          ),
+        )),
+      ) as _i3.Future<Duration>);
+
+  @override
+  _i3.Future<DateTime?> ensureLastUpdateLoaded() => (super.noSuchMethod(
+        Invocation.method(
+          #ensureLastUpdateLoaded,
+          [],
+        ),
+        returnValue: _i3.Future<DateTime?>.value(),
+      ) as _i3.Future<DateTime?>);
 }

--- a/mobile/test/presentation/view_models/dashboard_view_model_test.dart
+++ b/mobile/test/presentation/view_models/dashboard_view_model_test.dart
@@ -50,6 +50,8 @@ void main() {
     when(mockSettingsRepository.getTargetWeeklyHours()).thenReturn(40.0);
     when(mockOvertimeRepository.getOvertime()).thenReturn(Duration.zero);
     when(mockOvertimeRepository.getLastUpdateDate()).thenReturn(null);
+    when(mockOvertimeRepository.ensureOvertimeLoaded()).thenAnswer((_) async => Duration.zero);
+    when(mockOvertimeRepository.ensureLastUpdateLoaded()).thenAnswer((_) async => null);
     when(mockGetOvertime()).thenReturn(Duration.zero);
   });
 
@@ -154,8 +156,10 @@ void main() {
       when(mockGetTodayWorkEntry()).thenAnswer((_) async => entry);
       // Mock Overtime Repository to return +10h
       when(mockOvertimeRepository.getOvertime()).thenReturn(const Duration(hours: 10));
+      when(mockOvertimeRepository.ensureOvertimeLoaded()).thenAnswer((_) async => const Duration(hours: 10));
       // Last update was yesterday (so it's fully initial)
       when(mockOvertimeRepository.getLastUpdateDate()).thenReturn(now.subtract(const Duration(days: 1)));
+      when(mockOvertimeRepository.ensureLastUpdateLoaded()).thenAnswer((_) async => now.subtract(const Duration(days: 1)));
 
       container.read(dashboardViewModelProvider.notifier);
       await Future.delayed(Duration.zero);

--- a/mobile/test/presentation/view_models/dashboard_view_model_test.mocks.dart
+++ b/mobile/test/presentation/view_models/dashboard_view_model_test.mocks.dart
@@ -415,4 +415,28 @@ class MockOvertimeRepository extends _i1.Mock
         returnValue: _i5.Future<void>.value(),
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<Duration> ensureOvertimeLoaded() => (super.noSuchMethod(
+        Invocation.method(
+          #ensureOvertimeLoaded,
+          [],
+        ),
+        returnValue: _i5.Future<Duration>.value(_FakeDuration_2(
+          this,
+          Invocation.method(
+            #ensureOvertimeLoaded,
+            [],
+          ),
+        )),
+      ) as _i5.Future<Duration>);
+
+  @override
+  _i5.Future<DateTime?> ensureLastUpdateLoaded() => (super.noSuchMethod(
+        Invocation.method(
+          #ensureLastUpdateLoaded,
+          [],
+        ),
+        returnValue: _i5.Future<DateTime?>.value(),
+      ) as _i5.Future<DateTime?>);
 }


### PR DESCRIPTION
… behoben

OvertimeRepository erhält zwei neue async-Methoden ensureOvertimeLoaded() und ensureLastUpdateLoaded(). Firebase-Implementierung lädt dabei echte Daten aus Firestore statt auf einen möglicherweise leeren synchronen Cache zu vertrauen.

Dashboard und Settings nutzen diese Methoden jetzt in _init(), wodurch der gespeicherte Überstundensaldo korrekt als Basis für die Tagesberechnung verwendet wird — auch direkt nach dem Login oder einem App-Neustart.