### PR TITLE
fix(overtime): manuelle Gleitzeit-Bilanz als Basis aus Vortagen behan…

### DIFF
--- a/mobile/lib/domain/usecases/overtime_usecases.dart
+++ b/mobile/lib/domain/usecases/overtime_usecases.dart
@@ -30,9 +30,10 @@ class SetOvertime {
 
   Future<void> call({required Duration overtime, bool isManual = false}) async {
     await repository.saveOvertime(overtime);
-    // Bei manueller Änderung das Datum speichern
     if (isManual) {
-      await repository.saveLastUpdateDate(DateTime.now());
+      // Epoch-Datum setzen damit _init den gespeicherten Wert als Basis behandelt
+      // (nicht als "heutiger Gesamtstand inkl. Daily-Overtime").
+      await repository.saveLastUpdateDate(DateTime.utc(1970, 1, 1));
     }
   }
 }

--- a/mobile/lib/presentation/screens/settings_page.dart
+++ b/mobile/lib/presentation/screens/settings_page.dart
@@ -365,7 +365,7 @@ class SettingsPage extends ConsumerWidget {
                 color: isNegative ? Colors.red : Colors.green,
               ),
         ),
-        if (lastUpdate != null) ...[
+        if (lastUpdate != null && lastUpdate.isAfter(DateTime(2000))) ...[
           const SizedBox(height: 4),
           Text(
             'Letzte manuelle Änderung: ${DateFormat('dd.MM.yyyy').format(lastUpdate)}',

--- a/mobile/lib/presentation/view_models/dashboard_view_model.dart
+++ b/mobile/lib/presentation/view_models/dashboard_view_model.dart
@@ -157,17 +157,13 @@ class DashboardViewModel extends Notifier<DashboardState> {
     );
   }
 
-  void updateOvertimeFromSettings(Duration newOvertime) {
-    // Wenn Overtime manuell gesetzt wird, ist das der neue Total/Base Wert.
-    // Wir setzen Base auf den neuen Wert und behalten Daily bei.
-    // Total = Base + Daily.
-    // Aber wenn der User "Total" editiert, meint er meistens "Total inkl. heute".
-    // Angenommen er setzt Total auf X.
-    // Dann ist Base = X - Daily.
+  void updateOvertimeFromSettings(Duration newBase) {
+    // Der User gibt die Basis-Bilanz aus Vortagen ein (nicht inkl. heute).
+    // Total = Basis + Heutige Überstunden.
     final currentDaily = state.dailyOvertime ?? Duration.zero;
     state = state.copyWith(
-      initialOvertime: newOvertime - currentDaily,
-      totalOvertime: newOvertime,
+      initialOvertime: newBase,
+      totalOvertime: newBase + currentDaily,
     );
   }
 

--- a/web/src/app/core/services/overtime.ts
+++ b/web/src/app/core/services/overtime.ts
@@ -25,14 +25,26 @@ export class OvertimeService {
 
   async saveOvertime(ms: number): Promise<void> {
     const uid = this.auth.uid;
-    if (uid) await this._firebaseSave(uid, ms, new Date());
-    else     this._localSave(ms, new Date());
+    if (uid) {
+      const ref = doc(this.firestore, `users/${uid}/overtime/balance`);
+      await runInInjectionContext(this.injector, () =>
+        setDoc(ref, { minutes: Math.round(ms / 60000) }, { merge: true })
+      );
+    } else {
+      localStorage.setItem(LS_OVERTIME, String(Math.round(ms / 60000)));
+    }
   }
 
   async saveLastUpdateDate(date: Date): Promise<void> {
     const uid = this.auth.uid;
-    if (uid) await this._firebaseSave(uid, await this.getOvertime(), date);
-    else     localStorage.setItem(LS_LAST_UPDATE, date.toISOString());
+    if (uid) {
+      const ref = doc(this.firestore, `users/${uid}/overtime/balance`);
+      await runInInjectionContext(this.injector, () =>
+        setDoc(ref, { lastUpdated: date }, { merge: true })
+      );
+    } else {
+      localStorage.setItem(LS_LAST_UPDATE, date.toISOString());
+    }
   }
 
   // ─── Firebase (Flutter-kompatibles Format: overtime/balance, minutes, lastUpdated) ─
@@ -52,13 +64,6 @@ export class OvertimeService {
     return raw ? (raw as { toDate(): Date }).toDate() : null;
   }
 
-  private async _firebaseSave(uid: string, ms: number, date: Date): Promise<void> {
-    const ref = doc(this.firestore, `users/${uid}/overtime/balance`);
-    await runInInjectionContext(this.injector, () =>
-      setDoc(ref, { minutes: Math.round(ms / 60 / 1000), lastUpdated: date }, { merge: true })
-    );
-  }
-
   // ─── localStorage ──────────────────────────────────────────────────────────
 
   private _localGetOvertime(): number {
@@ -69,10 +74,5 @@ export class OvertimeService {
   private _localGetLastUpdate(): Date | null {
     const raw = localStorage.getItem(LS_LAST_UPDATE);
     return raw ? new Date(raw) : null;
-  }
-
-  private _localSave(ms: number, date: Date): void {
-    localStorage.setItem(LS_OVERTIME, String(Math.round(ms / 60 / 1000)));
-    localStorage.setItem(LS_LAST_UPDATE, date.toISOString());
   }
 }

--- a/web/src/app/features/dashboard/dashboard.service.ts
+++ b/web/src/app/features/dashboard/dashboard.service.ts
@@ -304,16 +304,17 @@ export class DashboardService {
   }
 
   // ─── Flow 12: Überstunden manuell anpassen ────────────────────────────────
-  async updateInitialOvertime(newTotalMs: number): Promise<void> {
+  // newBaseMs = Basis-Bilanz aus Vortagen (NICHT inkl. heutiger Daily-Overtime).
+  async updateInitialOvertime(newBaseMs: number): Promise<void> {
     const daily = this._s().dailyOvertimeMs ?? 0;
-    const newInitial = newTotalMs - daily;
     this._s.update(s => ({
       ...s,
-      initialOvertimeMs: newInitial,
-      totalOvertimeMs:   newTotalMs,
+      initialOvertimeMs: newBaseMs,
+      totalOvertimeMs:   newBaseMs + daily,
     }));
-    await this.overtimeSvc.saveOvertime(newTotalMs);
-    await this.overtimeSvc.saveLastUpdateDate(new Date());
+    // Nur minutes speichern — kein lastUpdated-Update.
+    // So behandelt _init den Wert beim nächsten Load als Basis, nicht als heutigen Total.
+    await this.overtimeSvc.saveOvertime(newBaseMs);
   }
 
   // ─── Timer Internals ──────────────────────────────────────────────────────

--- a/web/src/app/features/settings/settings.service.ts
+++ b/web/src/app/features/settings/settings.service.ts
@@ -8,6 +8,7 @@ import { OvertimeService } from '../../core/services/overtime';
 import { ThemeService } from '../../core/services/theme';
 import { DataSyncService, DataSyncResult } from '../../core/services/data-sync';
 import { WebPremiumService } from '../../core/services/web-premium.service';
+import { DashboardService } from '../dashboard/dashboard.service';
 import { UserSettings } from '../../shared/models/index';
 
 const DEFAULT_SETTINGS: UserSettings = {
@@ -30,6 +31,7 @@ export class SettingsPageService {
   private readonly themeSvc       = inject(ThemeService);
   private readonly dataSyncSvc    = inject(DataSyncService);
   private readonly premiumSvc     = inject(WebPremiumService);
+  private readonly dashboardSvc   = inject(DashboardService);
   private readonly router         = inject(Router);
 
   // ── Auth / Premium ────────────────────────────────────────────────────────
@@ -100,10 +102,10 @@ export class SettingsPageService {
   }
 
   async setOvertime(ms: number): Promise<void> {
-    await this.overtimeSvc.saveOvertime(ms);
+    // Dashboard live aktualisieren + Basis-Wert speichern (ohne lastUpdated zu setzen).
+    // Der eingegebene Wert ist die Basis aus Vortagen, nicht der heutige Gesamtstand.
+    await this.dashboardSvc.updateInitialOvertime(ms);
     this._overtimeMs.set(ms);
-    this._lastOvertimeUpdate.set(new Date());
-    await this.overtimeSvc.saveLastUpdateDate(new Date());
   }
 
   setTheme(dark: boolean): void {


### PR DESCRIPTION
…deln

Der eingegebene Wert in "Überstunden / Minusstunden anpassen" wurde fälschlicherweise als aktueller Gesamtstand (inkl. heutiger Daily-Overtime) interpretiert. Dadurch wuchs "Überstunden Gesamt" im Tagesverlauf über den eingegebenen Wert hinaus, und die Feierabend-Berechnung ("Mit Gleitzeit- Bilanz auf 0") war falsch.

Der Wert wird jetzt korrekt als Basis aus abgeschlossenen Vortagen behandelt:
  Total = Basis + heutige Überstunden

Außerdem:
- Flutter: lastUpdated wird bei manueller Anpassung auf Epoch gesetzt, damit _init den Wert beim nächsten App-Start als Basis lädt (nicht als Total).
- Web: saveOvertime und saveLastUpdateDate sind jetzt sauber getrennt.
- Web: Settings benachrichtigt DashboardService für sofortiges Live-Update (vorher wurde das Dashboard gar nicht aktualisiert).