### PR TITLE
Zeiterfassung durchgängig auf Minutengenauigkeit umstellen

### DIFF
--- a/mobile/lib/core/utils/time_precision.dart
+++ b/mobile/lib/core/utils/time_precision.dart
@@ -1,0 +1,44 @@
+/// Zentrale Helfer für die minutengenaue Zeiterfassung.
+///
+/// Die App erfasst, speichert und rechnet ausschließlich minutengenau.
+/// Sekunden und Millisekunden werden dabei kaufmännisch gerundet
+/// (ab 30 Sekunden auf, darunter ab). So stimmen die angezeigte Uhrzeit
+/// (`HH:mm`) und der Wert, mit dem gerechnet wird, immer überein.
+library;
+
+/// Rundet einen Zeitstempel kaufmännisch auf die nächste volle Minute.
+///
+/// `08:00:29` -> `08:00`, `08:00:30` -> `08:01`.
+DateTime roundToMinute(DateTime time) {
+  final fraction = Duration(
+    seconds: time.second,
+    milliseconds: time.millisecond,
+    microseconds: time.microsecond,
+  );
+  final floored = time.subtract(fraction);
+  return fraction.inMicroseconds * 2 >= Duration.microsecondsPerMinute
+      ? floored.add(const Duration(minutes: 1))
+      : floored;
+}
+
+/// Wie [roundToMinute], akzeptiert aber `null` (z. B. für eine offene Endzeit).
+DateTime? roundToMinuteOrNull(DateTime? time) =>
+    time == null ? null : roundToMinute(time);
+
+/// Der aktuelle Zeitpunkt, kaufmännisch auf die volle Minute gerundet.
+///
+/// Diese Funktion ist die einzige Quelle für automatisch erfasste Zeitstempel
+/// (Arbeitsbeginn/-ende, Pausenbeginn/-ende).
+DateTime nowToMinute() => roundToMinute(DateTime.now());
+
+/// Rundet eine Dauer kaufmännisch auf volle Minuten.
+///
+/// Rundet symmetrisch: `+30s` -> `+1min`, `-30s` -> `-1min`. Damit driftet
+/// eine Gleitzeit-Bilanz im Minus nicht anders als im Plus.
+Duration roundDurationToMinute(Duration duration) => Duration(
+      minutes: (duration.inMicroseconds / Duration.microsecondsPerMinute).round(),
+    );
+
+/// Eine Dauer als volle Minuten für die Persistenz (kaufmännisch gerundet).
+int toStoredMinutes(Duration duration) =>
+    roundDurationToMinute(duration).inMinutes;

--- a/mobile/lib/data/datasources/local/storage_datasource.dart
+++ b/mobile/lib/data/datasources/local/storage_datasource.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart' show ThemeMode;
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 /// Die Schnittstelle (der "Vertrag") für unsere lokale Speicher-Datenquelle.
 /// Sie definiert, welche Operationen für App-Einstellungen möglich sein müssen.
@@ -74,6 +75,6 @@ class StorageDataSourceImpl implements StorageDataSource {
 
   @override
   Future<void> saveOvertime(Duration overtime) async {
-    await _prefs.setInt(_overtimeKey, overtime.inMinutes);
+    await _prefs.setInt(_overtimeKey, toStoredMinutes(overtime));
   }
 }

--- a/mobile/lib/data/datasources/remote/firestore_datasource.dart
+++ b/mobile/lib/data/datasources/remote/firestore_datasource.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
 
 import '../../models/work_entry_model.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 abstract class FirestoreDataSource {
   Stream<firebase.User?> get authStateChanges;
@@ -267,11 +268,11 @@ class FirestoreDataSourceImpl implements FirestoreDataSource {
 
   @override
   Future<void> saveOvertime(String userId, Duration overtime) async {
-    logger.i('[Firestore] Speichere Overtime für User: $userId, Wert: ${overtime.inMinutes} Minuten');
+    logger.i('[Firestore] Speichere Overtime für User: $userId, Wert: ${toStoredMinutes(overtime)} Minuten');
     final docRef = _getOvertimeDocRef(userId);
 
     await docRef.set({
-      'minutes': overtime.inMinutes,
+      'minutes': toStoredMinutes(overtime),
     }, SetOptions(merge: true));
   }
 

--- a/mobile/lib/data/models/break_model.dart
+++ b/mobile/lib/data/models/break_model.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:uuid/uuid.dart';
 
 import '../../domain/entities/break_entity.dart';
@@ -20,8 +21,8 @@ class BreakModel extends BreakEntity {
   factory BreakModel.fromEntity(BreakEntity entity) {
     return BreakModel(
       name: entity.name,
-      start: entity.start,
-      end: entity.end,
+      start: roundToMinute(entity.start),
+      end: roundToMinuteOrNull(entity.end),
     );
   }
 
@@ -33,8 +34,8 @@ class BreakModel extends BreakEntity {
   factory BreakModel.fromMap(Map<String, dynamic> map) {
     return BreakModel(
       name: map['name'] as String? ?? 'Pause', // Fallback, falls der Name fehlt
-      start: (map['start'] as Timestamp).toDate(),
-      end: (map['end'] as Timestamp?)?.toDate(),
+      start: roundToMinute((map['start'] as Timestamp).toDate()),
+      end: roundToMinuteOrNull((map['end'] as Timestamp?)?.toDate()),
     );
   }
 
@@ -46,9 +47,9 @@ class BreakModel extends BreakEntity {
     return {
       'name': name,
       // Wandle Dart DateTime in Firestore Timestamp um.
-      'start': Timestamp.fromDate(start),
+      'start': Timestamp.fromDate(roundToMinute(start)),
       // Wandle das optionale DateTime? in ein optionales Timestamp? um.
-      'end': end != null ? Timestamp.fromDate(end!) : null,
+      'end': end != null ? Timestamp.fromDate(roundToMinute(end!)) : null,
     };
   }
 }

--- a/mobile/lib/data/models/work_entry_model.dart
+++ b/mobile/lib/data/models/work_entry_model.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart' show DateUtils;
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:intl/intl.dart';
 
 import '../../domain/entities/work_entry_entity.dart';
@@ -35,8 +36,8 @@ class WorkEntryModel extends WorkEntryEntity {
     return WorkEntryModel(
       id: entity.id,
       date: entity.date,
-      workStart: entity.workStart,
-      workEnd: entity.workEnd,
+      workStart: roundToMinuteOrNull(entity.workStart),
+      workEnd: roundToMinuteOrNull(entity.workEnd),
       manualOvertime: entity.manualOvertime,
       breaks: entity.breaks.map((e) => BreakModel.fromEntity(e)).toList(),
       description: entity.description,
@@ -49,8 +50,8 @@ class WorkEntryModel extends WorkEntryEntity {
     return WorkEntryModel(
       id: '', // Die ID ist nicht Teil der Map, sie wird vom Aufrufer gesetzt.
       date: (map['date'] as Timestamp).toDate(),
-      workStart: (map['workStart'] as Timestamp?)?.toDate(),
-      workEnd: (map['workEnd'] as Timestamp?)?.toDate(),
+      workStart: roundToMinuteOrNull((map['workStart'] as Timestamp?)?.toDate()),
+      workEnd: roundToMinuteOrNull((map['workEnd'] as Timestamp?)?.toDate()),
       breaks: (map['breaks'] as List<dynamic>?)
               ?.map((breakData) => BreakModel.fromMap(breakData as Map<String, dynamic>))
               .toList() ??
@@ -80,10 +81,11 @@ class WorkEntryModel extends WorkEntryEntity {
   Map<String, dynamic> toMap() {
     return {
       'date': Timestamp.fromDate(DateTime.utc(date.year, date.month, date.day)),
-      'workStart': workStart != null ? Timestamp.fromDate(workStart!) : null,
-      'workEnd': workEnd != null ? Timestamp.fromDate(workEnd!) : null,
+      'workStart': workStart != null ? Timestamp.fromDate(roundToMinute(workStart!)) : null,
+      'workEnd': workEnd != null ? Timestamp.fromDate(roundToMinute(workEnd!)) : null,
       'breaks': breaks.map((b) => BreakModel.fromEntity(b).toMap()).toList(),
-      'manualOvertimeMinutes': manualOvertime?.inMinutes,
+      'manualOvertimeMinutes':
+          manualOvertime != null ? toStoredMinutes(manualOvertime!) : null,
       'description': description,
       'isManuallyEntered': isManuallyEntered,
       'type': type.name,

--- a/mobile/lib/data/repositories/firebase_overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/firebase_overtime_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_work_time/core/utils/logger.dart';
 import 'package:flutter_work_time/data/datasources/remote/firestore_datasource.dart';
 import 'package:flutter_work_time/domain/repositories/overtime_repository.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 /// Repository für Überstunden, das Firestore als Backend nutzt.
 /// Wird verwendet, wenn der User eingeloggt ist.
@@ -36,9 +37,12 @@ class FirebaseOvertimeRepositoryImpl implements OvertimeRepository {
 
   @override
   Future<void> saveOvertime(Duration overtime) async {
-    logger.i('[FirebaseOvertimeRepository] saveOvertime: ${overtime.inMinutes} min');
-    _cachedOvertime = overtime;
-    await _dataSource.saveOvertime(_userId, overtime);
+    // Minutengenau speichern — der Cache muss denselben Wert halten wie Firestore,
+    // sonst driftet die Bilanz zwischen Cache und persistiertem Stand.
+    final rounded = roundDurationToMinute(overtime);
+    logger.i('[FirebaseOvertimeRepository] saveOvertime: ${rounded.inMinutes} min');
+    _cachedOvertime = rounded;
+    await _dataSource.saveOvertime(_userId, rounded);
   }
 
   @override

--- a/mobile/lib/data/repositories/local_overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/local_overtime_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
 
 import '../../domain/repositories/overtime_repository.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 /// Lokales Repository für Überstunden ohne User-ID.
 /// Funktioniert auch ohne Login.
@@ -22,8 +23,8 @@ class LocalOvertimeRepositoryImpl implements OvertimeRepository {
 
   @override
   Future<void> saveOvertime(Duration overtime) async {
-    logger.i('[LocalOvertimeRepository] saveOvertime, key: $_overtimeKey, value: ${overtime.inMinutes} min');
-    final success = await _prefs.setInt(_overtimeKey, overtime.inMinutes);
+    logger.i('[LocalOvertimeRepository] saveOvertime, key: $_overtimeKey, value: ${toStoredMinutes(overtime)} min');
+    final success = await _prefs.setInt(_overtimeKey, toStoredMinutes(overtime));
     logger.i('[LocalOvertimeRepository] Save success: $success');
 
     // Verifiziere, dass der Wert gespeichert wurde

--- a/mobile/lib/data/repositories/local_work_repository_impl.dart
+++ b/mobile/lib/data/repositories/local_work_repository_impl.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 import '../../domain/entities/break_entity.dart';
 import '../../domain/entities/work_entry_entity.dart';
@@ -34,10 +35,10 @@ class LocalWorkRepositoryImpl implements WorkRepository {
       id: WorkEntryModel.generateId(date),
       date: date,
       workStart: data['workStart'] != null
-          ? DateTime.parse(data['workStart'] as String)
+          ? roundToMinute(DateTime.parse(data['workStart'] as String))
           : null,
       workEnd: data['workEnd'] != null
-          ? DateTime.parse(data['workEnd'] as String)
+          ? roundToMinute(DateTime.parse(data['workEnd'] as String))
           : null,
       breaks: (data['breaks'] as List<dynamic>?)
               ?.map((breakData) {
@@ -63,10 +64,12 @@ class LocalWorkRepositoryImpl implements WorkRepository {
   /// Konvertiert WorkEntryEntity zu lokalen JSON-Daten
   Map<String, dynamic> _toLocalJson(WorkEntryEntity entry) {
     return {
-      'workStart': entry.workStart?.toIso8601String(),
-      'workEnd': entry.workEnd?.toIso8601String(),
+      'workStart': roundToMinuteOrNull(entry.workStart)?.toIso8601String(),
+      'workEnd': roundToMinuteOrNull(entry.workEnd)?.toIso8601String(),
       'breaks': entry.breaks.map((b) => _breakToLocalJson(b)).toList(),
-      'manualOvertimeMinutes': entry.manualOvertime?.inMinutes,
+      'manualOvertimeMinutes': entry.manualOvertime != null
+          ? toStoredMinutes(entry.manualOvertime!)
+          : null,
       'description': entry.description,
       'isManuallyEntered': entry.isManuallyEntered,
       'type': entry.type.name,
@@ -78,8 +81,10 @@ class LocalWorkRepositoryImpl implements WorkRepository {
     return BreakEntity(
       id: data['id'] as String,
       name: data['name'] as String,
-      start: DateTime.parse(data['start'] as String),
-      end: data['end'] != null ? DateTime.parse(data['end'] as String) : null,
+      start: roundToMinute(DateTime.parse(data['start'] as String)),
+      end: data['end'] != null
+          ? roundToMinute(DateTime.parse(data['end'] as String))
+          : null,
       isAutomatic: data['isAutomatic'] as bool? ?? false,
     );
   }
@@ -89,8 +94,8 @@ class LocalWorkRepositoryImpl implements WorkRepository {
     return {
       'id': breakEntity.id,
       'name': breakEntity.name,
-      'start': breakEntity.start.toIso8601String(),
-      'end': breakEntity.end?.toIso8601String(),
+      'start': roundToMinute(breakEntity.start).toIso8601String(),
+      'end': roundToMinuteOrNull(breakEntity.end)?.toIso8601String(),
       'isAutomatic': breakEntity.isAutomatic,
     };
   }

--- a/mobile/lib/data/repositories/overtime_repository_impl.dart
+++ b/mobile/lib/data/repositories/overtime_repository_impl.dart
@@ -2,6 +2,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
 
 import '../../domain/repositories/overtime_repository.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 class OvertimeRepositoryImpl implements OvertimeRepository {
   static const String _overtimeKey = 'overtime_minutes';
@@ -24,8 +25,8 @@ class OvertimeRepositoryImpl implements OvertimeRepository {
 
   @override
   Future<void> saveOvertime(Duration overtime) async {
-    logger.i('[OvertimeRepository] saveOvertime for userId $_userId, key: $_userPrefKey, value: ${overtime.inMinutes} min');
-    final success = await _prefs.setInt(_userPrefKey, overtime.inMinutes);
+    logger.i('[OvertimeRepository] saveOvertime for userId $_userId, key: $_userPrefKey, value: ${toStoredMinutes(overtime)} min');
+    final success = await _prefs.setInt(_userPrefKey, toStoredMinutes(overtime));
     logger.i('[OvertimeRepository] Save success: $success');
 
     // Verifiziere, dass der Wert gespeichert wurde

--- a/mobile/lib/domain/entities/work_entry_extensions.dart
+++ b/mobile/lib/domain/entities/work_entry_extensions.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_work_time/core/utils/time_precision.dart';
+
 import 'work_entry_entity.dart';
 
 /// Diese Erweiterung fügt der WorkEntryEntity reine Berechnungslogik hinzu,
@@ -8,7 +10,7 @@ extension WorkEntryCalculations on WorkEntryEntity {
   /// Wenn der Timer noch läuft, wird die Zeit bis "jetzt" berechnet.
   Duration get calculatedWorkDuration {
     if (workStart == null) return Duration.zero;
-    final end = workEnd ?? DateTime.now();
+    final end = workEnd ?? nowToMinute();
     return end.difference(workStart!);
   }
 

--- a/mobile/lib/domain/usecases/start_or_stop_timer.dart
+++ b/mobile/lib/domain/usecases/start_or_stop_timer.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_work_time/core/utils/time_precision.dart';
+
 import '../entities/work_entry_entity.dart';
 import '../repositories/work_repository.dart';
 
@@ -14,10 +16,10 @@ class StartOrStopTimer {
 
     if (currentEntry.workStart == null) {
       // Fall 1: Timer wurde noch nicht gestartet. -> STARTEN
-      updatedEntry = currentEntry.copyWith(workStart: DateTime.now());
+      updatedEntry = currentEntry.copyWith(workStart: nowToMinute());
     } else if (currentEntry.workEnd == null) {
       // Fall 2: Timer läuft, aber wurde noch nicht gestoppt. -> STOPPEN
-      updatedEntry = currentEntry.copyWith(workEnd: DateTime.now());
+      updatedEntry = currentEntry.copyWith(workEnd: nowToMinute());
     } else {
       // Fall 3: Timer wurde bereits gestoppt. Nichts tun.
       return currentEntry;

--- a/mobile/lib/domain/usecases/toggle_break.dart
+++ b/mobile/lib/domain/usecases/toggle_break.dart
@@ -1,6 +1,8 @@
 import 'package:collection/collection.dart';
 import 'package:uuid/uuid.dart';
 
+import 'package:flutter_work_time/core/utils/time_precision.dart';
+
 import '../entities/break_entity.dart';
 import '../entities/work_entry_entity.dart';
 import '../repositories/work_repository.dart';
@@ -26,7 +28,7 @@ class ToggleBreak {
       final updatedBreaks = currentEntry.breaks.map((b) {
         if (b == activeBreak) {
           // Erstelle eine neue Instanz der Pause mit gesetzter Endzeit.
-          return b.copyWith(end: DateTime.now());
+          return b.copyWith(end: nowToMinute());
         }
         return b;
       }).toList();
@@ -37,7 +39,7 @@ class ToggleBreak {
       final newBreak = BreakEntity(
         id: const Uuid().v4(),
         name: 'Pause ${currentEntry.breaks.length + 1}',
-        start: DateTime.now(),
+        start: nowToMinute(),
       );
 
       // Füge die neue Pause zur Liste der Pausen hinzu.

--- a/mobile/lib/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/presentation/screens/dashboard_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:intl/intl.dart';
 
 import '../../domain/entities/break_entity.dart';
@@ -16,8 +17,7 @@ class DashboardScreen extends ConsumerWidget {
     String twoDigits(int n) => n.toString().padLeft(2, '0');
     final hours = twoDigits(duration.inHours);
     final minutes = twoDigits(duration.inMinutes.remainder(60));
-    final seconds = twoDigits(duration.inSeconds.remainder(60));
-    return "$hours:$minutes:$seconds";
+    return "$hours:$minutes";
   }
 
   String _formatOvertime(Duration overtime) {
@@ -47,7 +47,7 @@ class DashboardScreen extends ConsumerWidget {
     final netDuration = dashboardState.actualWorkDuration ?? dashboardState.elapsedTime;
     
     final totalBreakDuration = workEntryWithAutoBreaks.breaks.fold(Duration.zero, (prev, b) {
-      final end = b.end ?? DateTime.now();
+      final end = b.end ?? nowToMinute();
       return prev + end.difference(b.start);
     });
 

--- a/mobile/lib/presentation/screens/reports_page.dart
+++ b/mobile/lib/presentation/screens/reports_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:intl/intl.dart';
 import 'package:purchases_ui_flutter/purchases_ui_flutter.dart';
 import '../../core/providers/subscription_provider.dart';
@@ -230,7 +231,7 @@ class DailyReportView extends ConsumerWidget {
           if (dE.type == WorkEntryType.work) {
             final DateTime? start = dE.workStart;
             // FIX: DateTime type, not DateTime? to ensure non-null usage later
-            final DateTime end = dE.workEnd ?? DateTime.now();
+            final DateTime end = dE.workEnd ?? nowToMinute();
             if (start != null) {
               // end is always not null due to ??
               Duration breakDur = Duration.zero;
@@ -439,7 +440,7 @@ class DailyReportView extends ConsumerWidget {
                     .read(reportsViewModelProvider.notifier)
                     .applyBreakCalculation(entry);
                 final DateTime? start = displayEntry.workStart;
-                final DateTime end = displayEntry.workEnd ?? DateTime.now();
+                final DateTime end = displayEntry.workEnd ?? nowToMinute();
                 Duration breakDuration = Duration.zero;
                 if (start != null) {
                   for (final b in displayEntry.breaks) {
@@ -1653,7 +1654,7 @@ class _DayEntriesBottomSheetState extends ConsumerState<DayEntriesBottomSheet> {
 
                         final DateTime? start = displayEntry.workStart;
                         final DateTime? end =
-                            displayEntry.workEnd ?? DateTime.now();
+                            displayEntry.workEnd ?? nowToMinute();
                         Duration worked = Duration.zero;
 
                         if (start != null && end != null) {

--- a/mobile/lib/presentation/state/weekly_report_state.dart
+++ b/mobile/lib/presentation/state/weekly_report_state.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 @immutable
 class WeeklyReportState {
@@ -20,8 +21,9 @@ class WeeklyReportState {
     this.dailyWork = const {},
   });
 
-  Duration get avgWorkDurationPerDay => workDays > 0 
-      ? Duration(seconds: totalWorkDuration.inSeconds ~/ workDays) 
+  Duration get avgWorkDurationPerDay => workDays > 0
+      ? roundDurationToMinute(
+          Duration(microseconds: totalWorkDuration.inMicroseconds ~/ workDays))
       : Duration.zero;
 
   static const WeeklyReportState initial = WeeklyReportState();

--- a/mobile/lib/presentation/view_models/dashboard_view_model.dart
+++ b/mobile/lib/presentation/view_models/dashboard_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 import '../../core/providers/providers.dart';
 import '../../domain/entities/break_entity.dart';
@@ -58,7 +59,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     } else if (workEntry.workStart != null) {
       // Laufender Tag -> Overtime wird im Timer berechnet.
       // Um initialOvertime (Basis) korrekt wiederherzustellen, müssen wir den aktuellen "Tagesfortschritt" vom gespeicherten Gesamtwert abziehen.
-      final now = DateTime.now();
+      final now = nowToMinute();
 
       // Berechne aktuelle Pausenzeit
       final breakDuration = _calculateTotalBreakDuration(now);
@@ -143,12 +144,12 @@ class DashboardViewModel extends Notifier<DashboardState> {
     final settingsRepository = ref.read(settingsRepositoryProvider);
     final workdaysPerWeek = settingsRepository.getWorkdaysPerWeek();
     if (workdaysPerWeek <= 0) return Duration.zero;
-    final regularDailyTarget = Duration(
+    final regularDailyTarget = roundDurationToMinute(Duration(
       microseconds: (settingsRepository.getTargetWeeklyHours() /
               workdaysPerWeek *
               Duration.microsecondsPerHour)
           .round(),
-    );
+    ));
     return getEffectiveDailyTarget(
       date: DateTime.now(),
       weekEntries: _weekEntries,
@@ -186,7 +187,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
       _tickCounter = 0;
       
       // Sofortiges Update
-      final now = DateTime.now();
+      final now = nowToMinute();
       final initialElapsedTime = _calculateElapsedTime();
       final initialGrossDuration = now.difference(state.workEntry.workStart!);
       
@@ -197,7 +198,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
       _recalculateOvertime();
       
       _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-        final now = DateTime.now();
+        final now = nowToMinute();
         final elapsedTime = _calculateElapsedTime();
         final grossDuration = state.workEntry.workStart != null 
             ? now.difference(state.workEntry.workStart!) 
@@ -240,7 +241,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
 
   Duration _calculateElapsedTime() {
     if (state.workEntry.workStart == null) return Duration.zero;
-    final now = DateTime.now();
+    final now = nowToMinute();
     final breakDuration = _calculateTotalBreakDuration(now);
     return now.difference(state.workEntry.workStart!) - breakDuration;
   }
@@ -278,7 +279,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     if (state.workEntry.workStart == null) return null;
 
     final start = state.workEntry.workStart!;
-    final now = DateTime.now();
+    final now = nowToMinute();
     
     // Bereits genommene Pausen (bis jetzt)
     var currentBreaks = _calculateTotalBreakDuration(now);
@@ -320,7 +321,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
   }
 
   Future<void> startOrStopTimer() async {
-    final now = DateTime.now();
+    final now = nowToMinute();
     WorkEntryEntity updatedEntry;
 
     if (state.workEntry.workStart == null) {
@@ -354,7 +355,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
 
   /// Startet eine komplett neue Session (Start, End und Pausen zurücksetzen)
   Future<void> startNewSession() async {
-    final now = DateTime.now();
+    final now = nowToMinute();
     final updatedEntry = WorkEntryEntity(
       id: state.workEntry.id,
       date: state.workEntry.date,
@@ -372,7 +373,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
 
   /// Neue Session mit Pausen behalten (nur Start und Endzeit zurücksetzen)
   Future<void> startNewSessionKeepBreaks() async {
-    final now = DateTime.now();
+    final now = nowToMinute();
     final updatedEntry = WorkEntryEntity(
       id: state.workEntry.id,
       date: state.workEntry.date,

--- a/mobile/lib/presentation/view_models/edit_work_entry_view_model.dart
+++ b/mobile/lib/presentation/view_models/edit_work_entry_view_model.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:uuid/uuid.dart';
 
@@ -22,19 +23,19 @@ class EditWorkEntryViewModel extends _$EditWorkEntryViewModel {
   }
 
   void setStartTime(DateTime startTime) {
-    state = state.copyWith(newStartTime: startTime);
+    state = state.copyWith(newStartTime: roundToMinute(startTime));
   }
 
   void setEndTime(DateTime? endTime) {
-    state = state.copyWith(newEndTime: endTime);
+    state = state.copyWith(newEndTime: roundToMinuteOrNull(endTime));
   }
 
   void addBreak() {
     final newBreak = BreakEntity(
       id: _uuid.v4(),
       name: 'Pause #${state.breaks.length + 1}',
-      start: state.newStartTime ?? DateTime.now(),
-      end: (state.newStartTime ?? DateTime.now())
+      start: state.newStartTime ?? nowToMinute(),
+      end: (state.newStartTime ?? nowToMinute())
           .add(const Duration(minutes: 30)),
     );
     state = state.copyWith(breaks: [...state.breaks, newBreak]);
@@ -49,8 +50,8 @@ class EditWorkEntryViewModel extends _$EditWorkEntryViewModel {
     final updatedBreaks = state.breaks.map((b) {
       if (b.id == breakId) {
         return b.copyWith(
-          start: newStart ?? b.start,
-          end: newEnd ?? b.end,
+          start: roundToMinuteOrNull(newStart) ?? b.start,
+          end: roundToMinuteOrNull(newEnd) ?? b.end,
           name: newName ?? b.name,
         );
       }

--- a/mobile/lib/presentation/view_models/reports_view_model.dart
+++ b/mobile/lib/presentation/view_models/reports_view_model.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_work_time/core/utils/logger.dart';
 import 'package:intl/intl.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 import '../../core/providers/providers.dart' as core_providers;
 import '../../domain/entities/work_entry_entity.dart';
@@ -196,12 +197,12 @@ class ReportsViewModel extends Notifier<ReportsState> {
     final settingsRepository = ref.read(core_providers.settingsRepositoryProvider);
     final workdaysPerWeek = settingsRepository.getWorkdaysPerWeek();
     if (workdaysPerWeek <= 0) return Duration.zero;
-    final regularDailyTarget = Duration(
+    final regularDailyTarget = roundDurationToMinute(Duration(
       microseconds: (settingsRepository.getTargetWeeklyHours() /
               workdaysPerWeek *
               Duration.microsecondsPerHour)
           .round(),
-    );
+    ));
 
     final weekEntries = getWeekEntriesForDate(date, _monthlyEntries);
     return getEffectiveDailyTarget(
@@ -239,7 +240,8 @@ class ReportsViewModel extends Notifier<ReportsState> {
         .toSet()
         .length;
     final averageWorkDuration = uniqueWorkDays > 0
-        ? Duration(seconds: totalNetWorkDuration.inSeconds ~/ uniqueWorkDays)
+        ? roundDurationToMinute(
+            Duration(microseconds: totalNetWorkDuration.inMicroseconds ~/ uniqueWorkDays))
         : Duration.zero;
 
     final workdaysPerWeek = settingsRepository.getWorkdaysPerWeek();
@@ -252,8 +254,8 @@ class ReportsViewModel extends Notifier<ReportsState> {
     final targetWeeklyHoursForActualWorkdaysInMicroseconds =
         (targetDailyHoursInDouble * effectiveWorkDays * Duration.microsecondsPerHour)
             .toInt();
-    final targetWeeklyHours =
-        Duration(microseconds: targetWeeklyHoursForActualWorkdaysInMicroseconds);
+    final targetWeeklyHours = roundDurationToMinute(
+        Duration(microseconds: targetWeeklyHoursForActualWorkdaysInMicroseconds));
     final overtime = totalNetWorkDuration - targetWeeklyHours;
 
     final manualOvertimes = entriesForWeek.fold<Duration>(
@@ -295,7 +297,10 @@ class ReportsViewModel extends Notifier<ReportsState> {
     final workDays = uniqueWorkDaysSet.length;
 
     final averageWorkDuration =
-        workDays > 0 ? Duration(microseconds: totalNetWorkDuration.inMicroseconds ~/ workDays) : Duration.zero;
+        workDays > 0
+            ? roundDurationToMinute(
+                Duration(microseconds: totalNetWorkDuration.inMicroseconds ~/ workDays))
+            : Duration.zero;
 
     final workdaysPerWeek = settingsRepository.getWorkdaysPerWeek();
     final targetDailyHours = workdaysPerWeek > 0
@@ -317,8 +322,8 @@ class ReportsViewModel extends Notifier<ReportsState> {
       effectiveTotalWorkDays += min(weekDays.length, workdaysPerWeek);
     }
 
-    final totalTargetHoursForActualWorkDays =
-        Duration(microseconds: (targetDailyHours * effectiveTotalWorkDays * Duration.microsecondsPerHour).toInt());
+    final totalTargetHoursForActualWorkDays = roundDurationToMinute(
+        Duration(microseconds: (targetDailyHours * effectiveTotalWorkDays * Duration.microsecondsPerHour).toInt()));
     final overtime = totalNetWorkDuration - totalTargetHoursForActualWorkDays;
 
     final manualOvertimes = _monthlyEntries.fold<Duration>(
@@ -344,7 +349,8 @@ class ReportsViewModel extends Notifier<ReportsState> {
     final numberOfWeeksWithWork = weeklyWork.keys.length;
     final totalWorkDurationInMonth = weeklyWork.values.fold(Duration.zero, (prev, current) => prev + current);
     final avgWorkDurationPerWeek = numberOfWeeksWithWork > 0 
-        ? Duration(microseconds: totalWorkDurationInMonth.inMicroseconds ~/ numberOfWeeksWithWork) 
+        ? roundDurationToMinute(Duration(
+            microseconds: totalWorkDurationInMonth.inMicroseconds ~/ numberOfWeeksWithWork))
         : Duration.zero;
 
 

--- a/mobile/lib/presentation/widgets/dashboard/time_summary_card.dart
+++ b/mobile/lib/presentation/widgets/dashboard/time_summary_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
 
 import '../../../core/providers/providers.dart';
 import '../../../domain/entities/work_entry_entity.dart';
@@ -15,7 +16,7 @@ class TimeSummaryCard extends ConsumerWidget {
 
   // Helper zum Formatieren einer Duration
   String _formatDuration(Duration duration) {
-    if (duration.inSeconds < 0) return "00h 00m";
+    if (duration.inMinutes < 0) return "00h 00m";
     final hours = duration.inHours.toString().padLeft(2, '0');
     final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
     return '${hours}h ${minutes}m';
@@ -25,9 +26,9 @@ class TimeSummaryCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settingsRepository = ref.watch(settingsRepositoryProvider);
     final workdaysPerWeek = settingsRepository.getWorkdaysPerWeek();
-    final targetDailyHours = Duration(
+    final targetDailyHours = roundDurationToMinute(Duration(
       microseconds: (settingsRepository.getTargetWeeklyHours() / workdaysPerWeek * Duration.microsecondsPerHour).round(),
-    );
+    ));
 
     return Card(
       elevation: 2,

--- a/mobile/lib/presentation/widgets/dashboard/timer_card.dart
+++ b/mobile/lib/presentation/widgets/dashboard/timer_card.dart
@@ -15,7 +15,7 @@ class TimerCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final timeFormat = DateFormat('HH:mm:ss');
+    final timeFormat = DateFormat('HH:mm');
     final bool isTimerRunning = workEntry.workStart != null && workEntry.workEnd == null;
     final bool isWorkDone = workEntry.workStart != null && workEntry.workEnd != null;
 
@@ -37,13 +37,13 @@ class TimerCard extends ConsumerWidget {
                   label: 'Start',
                   time: workEntry.workStart != null
                       ? timeFormat.format(workEntry.workStart!)
-                      : '--:--:--',
+                      : '--:--',
                 ),
                 _TimeDisplay(
                   label: 'Ende',
                   time: workEntry.workEnd != null
                       ? timeFormat.format(workEntry.workEnd!)
-                      : '--:--:--',
+                      : '--:--',
                 ),
               ],
             ),

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -60,7 +60,8 @@ dependencies:
 
 dependency_overrides:
   meta: ^1.17.0
-  test_api: ^0.7.8
+  test_api: 0.7.12
+  test_core: 0.6.18
   analyzer: ^8.0.0
   custom_lint_visitor: 1.0.0+8.4.0
 

--- a/mobile/test/core/utils/time_precision_test.dart
+++ b/mobile/test/core/utils/time_precision_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_work_time/core/utils/time_precision.dart';
+
+void main() {
+  group('roundToMinute', () {
+    test('rundet unter 30 Sekunden ab', () {
+      expect(
+        roundToMinute(DateTime(2024, 5, 6, 8, 0, 29, 999)),
+        DateTime(2024, 5, 6, 8, 0),
+      );
+    });
+
+    test('rundet ab genau 30 Sekunden auf', () {
+      expect(
+        roundToMinute(DateTime(2024, 5, 6, 8, 0, 30)),
+        DateTime(2024, 5, 6, 8, 1),
+      );
+    });
+
+    test('lässt eine volle Minute unverändert', () {
+      final exact = DateTime(2024, 5, 6, 8, 0);
+      expect(roundToMinute(exact), exact);
+    });
+
+    test('rundet über die Stunden- und Tagesgrenze korrekt', () {
+      expect(
+        roundToMinute(DateTime(2024, 5, 6, 8, 59, 45)),
+        DateTime(2024, 5, 6, 9, 0),
+      );
+      expect(
+        roundToMinute(DateTime(2024, 5, 6, 23, 59, 45)),
+        DateTime(2024, 5, 7, 0, 0),
+      );
+    });
+
+    test('entfernt auch Millisekunden und Mikrosekunden', () {
+      expect(
+        roundToMinute(DateTime(2024, 5, 6, 8, 0, 10, 500, 250)),
+        DateTime(2024, 5, 6, 8, 0),
+      );
+    });
+  });
+
+  group('roundToMinuteOrNull', () {
+    test('gibt null für null zurück', () {
+      expect(roundToMinuteOrNull(null), isNull);
+    });
+
+    test('rundet einen vorhandenen Wert', () {
+      expect(
+        roundToMinuteOrNull(DateTime(2024, 5, 6, 8, 0, 40)),
+        DateTime(2024, 5, 6, 8, 1),
+      );
+    });
+  });
+
+  group('nowToMinute', () {
+    test('liefert immer einen Zeitstempel ohne Sekundenanteil', () {
+      final now = nowToMinute();
+      expect(now.second, 0);
+      expect(now.millisecond, 0);
+      expect(now.microsecond, 0);
+    });
+  });
+
+  group('roundDurationToMinute', () {
+    test('rundet positive Dauern kaufmännisch', () {
+      expect(
+        roundDurationToMinute(const Duration(minutes: 5, seconds: 29)),
+        const Duration(minutes: 5),
+      );
+      expect(
+        roundDurationToMinute(const Duration(minutes: 5, seconds: 30)),
+        const Duration(minutes: 6),
+      );
+    });
+
+    test('rundet negative Dauern symmetrisch', () {
+      expect(
+        roundDurationToMinute(const Duration(minutes: -5, seconds: -29)),
+        const Duration(minutes: -5),
+      );
+      expect(
+        roundDurationToMinute(const Duration(minutes: -5, seconds: -30)),
+        const Duration(minutes: -6),
+      );
+    });
+  });
+
+  group('toStoredMinutes', () {
+    test('gibt gerundete volle Minuten zurück', () {
+      expect(toStoredMinutes(const Duration(hours: 1, seconds: 31)), 61);
+      expect(toStoredMinutes(const Duration(hours: -1, seconds: -31)), -61);
+    });
+  });
+}

--- a/mobile/test/presentation/widgets/dashboard/timer_card_test.dart
+++ b/mobile/test/presentation/widgets/dashboard/timer_card_test.dart
@@ -84,7 +84,7 @@ void main() {
       // Check text is present
       expect(find.text('Arbeit starten'), findsOneWidget);
       expect(find.text('08:00'), findsOneWidget);
-      expect(find.text('17:00:00'), findsOneWidget);
+      expect(find.text('17:00'), findsOneWidget);
       
       // Attempt to tap
       await tester.tap(find.text('Arbeit starten'));

--- a/mobile/test/presentation/widgets/dashboard/timer_card_test.dart
+++ b/mobile/test/presentation/widgets/dashboard/timer_card_test.dart
@@ -49,7 +49,7 @@ void main() {
       await tester.pumpWidget(createSubject(entry, fakeViewModel));
 
       expect(find.text('Arbeit starten'), findsOneWidget);
-      expect(find.text('--:--:--'), findsNWidgets(2)); // Start and End
+      expect(find.text('--:--'), findsNWidgets(2)); // Start and End
       expect(find.byIcon(Icons.play_circle_filled), findsOneWidget);
     });
 
@@ -65,8 +65,8 @@ void main() {
       await tester.pumpWidget(createSubject(entry, fakeViewModel));
 
       expect(find.text('Arbeit beenden'), findsOneWidget);
-      expect(find.text('08:00:00'), findsOneWidget); // Start time
-      expect(find.text('--:--:--'), findsOneWidget); // End time
+      expect(find.text('08:00'), findsOneWidget); // Start time
+      expect(find.text('--:--'), findsOneWidget); // End time
       expect(find.byIcon(Icons.pause_circle_filled), findsOneWidget);
     });
 
@@ -83,7 +83,7 @@ void main() {
 
       // Check text is present
       expect(find.text('Arbeit starten'), findsOneWidget);
-      expect(find.text('08:00:00'), findsOneWidget);
+      expect(find.text('08:00'), findsOneWidget);
       expect(find.text('17:00:00'), findsOneWidget);
       
       // Attempt to tap

--- a/web/src/app/core/services/overtime.ts
+++ b/web/src/app/core/services/overtime.ts
@@ -1,6 +1,7 @@
 import { Injectable, Injector, inject, runInInjectionContext } from '@angular/core';
 import { Firestore, doc, getDoc, setDoc } from '@angular/fire/firestore';
 import { AuthService } from '../auth/auth';
+import { toStoredMinutes } from '../../shared/utils/time-precision.util';
 
 const LS_OVERTIME    = 'overtime_value';
 const LS_LAST_UPDATE = 'overtime_last_update';
@@ -28,10 +29,10 @@ export class OvertimeService {
     if (uid) {
       const ref = doc(this.firestore, `users/${uid}/overtime/balance`);
       await runInInjectionContext(this.injector, () =>
-        setDoc(ref, { minutes: Math.round(ms / 60000) }, { merge: true })
+        setDoc(ref, { minutes: toStoredMinutes(ms) }, { merge: true })
       );
     } else {
-      localStorage.setItem(LS_OVERTIME, String(Math.round(ms / 60000)));
+      localStorage.setItem(LS_OVERTIME, String(toStoredMinutes(ms)));
     }
   }
 

--- a/web/src/app/core/services/work-entry.ts
+++ b/web/src/app/core/services/work-entry.ts
@@ -11,6 +11,7 @@ import {
 import { AuthService } from '../auth/auth';
 import { WorkEntry, WorkEntryType, Break } from '../../shared/models';
 import { Observable, of, switchMap } from 'rxjs';
+import { roundToMinute, roundToMinuteOrUndefined } from '../../shared/utils/time-precision.util';
 
 // localStorage Keys — identisch zu Flutter LocalWorkRepositoryImpl
 const LS_PREFIX = 'local_work_entries_';
@@ -143,8 +144,8 @@ export class WorkEntryService {
   private _toFirestore(entry: WorkEntry): Record<string, unknown> {
     return {
       date:                  Timestamp.fromDate(new Date(Date.UTC(entry.date.getFullYear(), entry.date.getMonth(), entry.date.getDate()))),
-      workStart:             entry.workStart ? Timestamp.fromDate(entry.workStart) : null,
-      workEnd:               entry.workEnd   ? Timestamp.fromDate(entry.workEnd)   : null,
+      workStart:             entry.workStart ? Timestamp.fromDate(roundToMinute(entry.workStart)) : null,
+      workEnd:               entry.workEnd   ? Timestamp.fromDate(roundToMinute(entry.workEnd))   : null,
       type:                  entry.type ?? WorkEntryType.Work,
       isManuallyEntered:     entry.isManuallyEntered ?? false,
       manualOvertimeMinutes: entry.manualOvertimeMinutes ?? null,
@@ -154,8 +155,8 @@ export class WorkEntryService {
         id:          b.id,
         name:        b.name,
         isAutomatic: b.isAutomatic,
-        start:       Timestamp.fromDate(b.start),
-        end:         b.end ? Timestamp.fromDate(b.end) : null,
+        start:       Timestamp.fromDate(roundToMinute(b.start)),
+        end:         b.end ? Timestamp.fromDate(roundToMinute(b.end)) : null,
       })),
     };
   }
@@ -163,11 +164,13 @@ export class WorkEntryService {
   private _fromFirestore(data: Record<string, unknown>, id: string): WorkEntry | null {
     try {
       const ts = (v: unknown) => v ? (v as Timestamp).toDate() : undefined;
+      // Zeitstempel minutengenau normalisieren (Altdaten können Sekunden enthalten)
+      const tsMin = (v: unknown) => roundToMinuteOrUndefined(ts(v));
       return {
         id,
         date:                  ts(data['date'])!,
-        workStart:             ts(data['workStart']),
-        workEnd:               ts(data['workEnd']),
+        workStart:             tsMin(data['workStart']),
+        workEnd:               tsMin(data['workEnd']),
         type:                  (data['type'] as WorkEntryType) ?? WorkEntryType.Work,
         isManuallyEntered:     (data['isManuallyEntered'] as boolean) ?? false,
         manualOvertimeMinutes: (data['manualOvertimeMinutes'] as number) ?? undefined,
@@ -176,8 +179,8 @@ export class WorkEntryService {
           id:          (b['id'] as string) || `break-${b['start']}`,
           name:        (b['name'] as string) || 'Pause',
           isAutomatic: (b['isAutomatic'] as boolean) ?? false,
-          start:       ts(b['start'])!,
-          end:         ts(b['end']),
+          start:       tsMin(b['start'])!,
+          end:         tsMin(b['end']),
         })) as Break[],
       };
     } catch {
@@ -246,23 +249,24 @@ export class WorkEntryService {
 
   private _toLocalJson(entry: WorkEntry): Record<string, unknown> {
     return {
-      workStart:             entry.workStart?.toISOString() ?? null,
-      workEnd:               entry.workEnd?.toISOString()   ?? null,
+      workStart:             roundToMinuteOrUndefined(entry.workStart)?.toISOString() ?? null,
+      workEnd:               roundToMinuteOrUndefined(entry.workEnd)?.toISOString()   ?? null,
       type:                  entry.type,
       isManuallyEntered:     entry.isManuallyEntered,
       manualOvertimeMinutes: entry.manualOvertimeMinutes ?? null,
       description:           entry.description ?? null,
       breaks: entry.breaks.map(b => ({
         id: b.id, name: b.name, isAutomatic: b.isAutomatic,
-        start: b.start.toISOString(),
-        end:   b.end?.toISOString() ?? null,
+        start: roundToMinute(b.start).toISOString(),
+        end:   roundToMinuteOrUndefined(b.end)?.toISOString() ?? null,
       })),
     };
   }
 
   private _fromLocalJson(data: Record<string, unknown>, date: Date): WorkEntry | null {
     try {
-      const parseDate = (v: unknown) => v ? new Date(v as string) : undefined;
+      const parseDate = (v: unknown) =>
+        v ? roundToMinute(new Date(v as string)) : undefined;
       return {
         id:                    this._dateId(date),
         date,
@@ -276,8 +280,8 @@ export class WorkEntryService {
           id:          b['id'] as string,
           name:        b['name'] as string,
           isAutomatic: (b['isAutomatic'] as boolean) ?? false,
-          start:       new Date(b['start'] as string),
-          end:         b['end'] ? new Date(b['end'] as string) : undefined,
+          start:       roundToMinute(new Date(b['start'] as string)),
+          end:         b['end'] ? roundToMinute(new Date(b['end'] as string)) : undefined,
         })) as Break[],
       };
     } catch { return null; }

--- a/web/src/app/domain/services/report-calculator.service.ts
+++ b/web/src/app/domain/services/report-calculator.service.ts
@@ -9,6 +9,7 @@ import {
   WeeklyReport,
   WeeklyReportDay,
 } from '../models/reports.models';
+import { roundMsToMinute } from '../../shared/utils/time-precision.util';
 
 // ─── Module-level helpers (no Angular DI) ─────────────────────────────────────
 
@@ -61,7 +62,8 @@ function filterByWeek(entries: WorkEntry[], date: Date): WorkEntry[] {
 }
 
 function dailyTargetMs(settings: UserSettings): number {
-  return (settings.weeklyTargetHours * 3600000) / settings.workdaysPerWeek;
+  // Auf volle Minuten runden — die App rechnet durchgehend minutengenau.
+  return roundMsToMinute((settings.weeklyTargetHours * 3600000) / settings.workdaysPerWeek);
 }
 
 // ─── Injectable Service ────────────────────────────────────────────────────────

--- a/web/src/app/features/dashboard/dashboard.service.ts
+++ b/web/src/app/features/dashboard/dashboard.service.ts
@@ -7,6 +7,7 @@ import { SettingsService }  from '../../core/services/settings';
 import { AuthService }      from '../../core/auth/auth';
 import { WorkEntry, WorkEntryType, Break } from '../../shared/models';
 import { calculateAndApplyBreaks } from '../../domain/services/break-calculator.service';
+import { nowToMinute, roundToMinute, roundMsToMinute } from '../../shared/utils/time-precision.util';
 import {
   getEffectiveDailyTarget,
   getWeekEntriesForDate,
@@ -140,7 +141,7 @@ export class DashboardService {
 
       // 5. Effektives Tagessoll berechnen
       const weeklyMs          = settings.weeklyTargetHours * 60 * 60 * 1000;
-      const regularDailyMs    = settings.workdaysPerWeek > 0 ? Math.round(weeklyMs / settings.workdaysPerWeek) : 0;
+      const regularDailyMs    = settings.workdaysPerWeek > 0 ? roundMsToMinute(weeklyMs / settings.workdaysPerWeek) : 0;
       const targetDailyMs     = getEffectiveDailyTarget(today, this._weekEntries, settings.workdaysPerWeek, regularDailyMs);
       const isExtraDay        = targetDailyMs === 0;
 
@@ -152,7 +153,7 @@ export class DashboardService {
         const netMs      = workEntry.workEnd.getTime() - workEntry.workStart.getTime() - breakMs;
         initialDailyMs   = netMs - targetDailyMs + manualEntryMs;
       } else if (workEntry.workStart) {
-        const now        = new Date();
+        const now        = nowToMinute();
         const breakMs    = this._totalBreakMs(workEntry.breaks, now);
         const netMs      = now.getTime() - workEntry.workStart.getTime() - breakMs;
         initialDailyMs   = netMs - targetDailyMs + manualEntryMs;
@@ -206,13 +207,13 @@ export class DashboardService {
     const e = this._s().workEntry;
     if (!e.workStart) {
       // START
-      const updated = { ...e, workStart: new Date(), workEnd: undefined };
+      const updated = { ...e, workStart: nowToMinute(), workEnd: undefined };
       await this._recalculateState(updated, true);
       this._startTimerIfNeeded();
     } else if (!e.workEnd) {
       // STOP
       this._stopTimer();
-      let updated: WorkEntry = { ...e, workEnd: new Date() };
+      let updated: WorkEntry = { ...e, workEnd: nowToMinute() };
       const hasRunningBreak = updated.breaks.some(b => !b.end);
       if (!hasRunningBreak && updated.type === WorkEntryType.Work) {
         updated = calculateAndApplyBreaks(updated);
@@ -230,7 +231,7 @@ export class DashboardService {
     const e = this._s().workEntry;
     const updated: WorkEntry = {
       ...e,
-      workStart:         new Date(),
+      workStart:         nowToMinute(),
       workEnd:           undefined,
       breaks:            keepBreaks ? e.breaks : [],
       isManuallyEntered: false,
@@ -246,12 +247,12 @@ export class DashboardService {
     let updatedBreaks: Break[];
 
     if (runningBreak) {
-      updatedBreaks = e.breaks.map(b => b.id === runningBreak.id ? { ...b, end: new Date() } : b);
+      updatedBreaks = e.breaks.map(b => b.id === runningBreak.id ? { ...b, end: nowToMinute() } : b);
     } else {
       const newBreak: Break = {
         id:          crypto.randomUUID(),
         name:        `Pause ${e.breaks.length + 1}`,
-        start:       new Date(),
+        start:       nowToMinute(),
         end:         undefined,
         isAutomatic: false,
       };
@@ -293,7 +294,12 @@ export class DashboardService {
   // ─── Flow 9: Pause bearbeiten ─────────────────────────────────────────────
   async updateBreak(updated: Break): Promise<void> {
     const e = this._s().workEntry;
-    const breaks = e.breaks.map(b => b.id === updated.id ? updated : b);
+    const normalized: Break = {
+      ...updated,
+      start: roundToMinute(updated.start),
+      end:   updated.end ? roundToMinute(updated.end) : undefined,
+    };
+    const breaks = e.breaks.map(b => b.id === updated.id ? normalized : b);
     await this._recalculateState({ ...e, breaks }, true);
   }
 
@@ -346,7 +352,7 @@ export class DashboardService {
   private _tick(): void {
     const e = this._s().workEntry;
     if (!e.workStart || e.workEnd) return;
-    const now    = new Date();
+    const now    = nowToMinute();
     const breakMs = this._totalBreakMs(e.breaks, now);
     const elapsed = now.getTime() - e.workStart.getTime() - breakMs;
     const gross   = now.getTime() - e.workStart.getTime();
@@ -367,7 +373,7 @@ export class DashboardService {
     const settings  = this._currentSettings();
     const targetMs  = this._targetDailyMs(settings);
     const manualMs  = (e.manualOvertimeMinutes ?? 0) * 60000;
-    const now       = new Date();
+    const now       = nowToMinute();
     const breakMs   = this._totalBreakMs(e.breaks, now);
     const elapsed   = now.getTime() - e.workStart.getTime() - breakMs;
     const daily     = elapsed - targetMs + manualMs;
@@ -462,7 +468,7 @@ export class DashboardService {
   private _targetDailyMs(settings: { weeklyTargetHours: number; workdaysPerWeek: number }): number {
     if (settings.workdaysPerWeek <= 0) return 0;
     const weeklyMs    = settings.weeklyTargetHours * 3600000;
-    const regularMs   = Math.round(weeklyMs / settings.workdaysPerWeek);
+    const regularMs   = roundMsToMinute(weeklyMs / settings.workdaysPerWeek);
     return getEffectiveDailyTarget(new Date(), this._weekEntries, settings.workdaysPerWeek, regularMs);
   }
 

--- a/web/src/app/features/dashboard/dashboard.ts
+++ b/web/src/app/features/dashboard/dashboard.ts
@@ -39,12 +39,11 @@ export class DashboardComponent {
   // ─── Template helpers ────────────────────────────────────────────────────────
 
   formatDuration(ms: number | null): string {
-    if (ms === null) return '00:00:00';
+    if (ms === null) return '00:00';
     const abs = Math.abs(ms);
     const h   = Math.floor(abs / 3600000);
     const m   = Math.floor((abs % 3600000) / 60000);
-    const s   = Math.floor((abs % 60000) / 1000);
-    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
   }
 
   formatOvertime(ms: number | null): string {

--- a/web/src/app/shared/utils/time-calculations.util.ts
+++ b/web/src/app/shared/utils/time-calculations.util.ts
@@ -1,11 +1,12 @@
 import { WorkEntry, Break, WorkEntryType } from '../models';
+import { nowToMinute } from './time-precision.util';
 
 /**
  * Berechnet die Brutto-Arbeitszeit in Minuten.
  */
 export function calculateGrossMinutes(entry: WorkEntry): number {
   if (!entry.workStart) return 0;
-  const end = entry.workEnd || new Date();
+  const end = entry.workEnd || nowToMinute();
   return (end.getTime() - entry.workStart.getTime()) / (1000 * 60);
 }
 

--- a/web/src/app/shared/utils/time-precision.util.spec.ts
+++ b/web/src/app/shared/utils/time-precision.util.spec.ts
@@ -1,0 +1,67 @@
+import {
+  nowToMinute,
+  roundMsToMinute,
+  roundToMinute,
+  roundToMinuteOrUndefined,
+  toStoredMinutes,
+} from './time-precision.util';
+
+describe('time-precision.util', () => {
+  describe('roundToMinute', () => {
+    it('rundet unter 30 Sekunden ab', () => {
+      expect(roundToMinute(new Date(2024, 4, 6, 8, 0, 29, 999)))
+        .toEqual(new Date(2024, 4, 6, 8, 0, 0, 0));
+    });
+
+    it('rundet ab genau 30 Sekunden auf', () => {
+      expect(roundToMinute(new Date(2024, 4, 6, 8, 0, 30)))
+        .toEqual(new Date(2024, 4, 6, 8, 1, 0, 0));
+    });
+
+    it('lässt eine volle Minute unverändert', () => {
+      const exact = new Date(2024, 4, 6, 8, 0, 0, 0);
+      expect(roundToMinute(exact)).toEqual(exact);
+    });
+
+    it('rundet über die Stunden- und Tagesgrenze korrekt', () => {
+      expect(roundToMinute(new Date(2024, 4, 6, 8, 59, 45)))
+        .toEqual(new Date(2024, 4, 6, 9, 0, 0, 0));
+      expect(roundToMinute(new Date(2024, 4, 6, 23, 59, 45)))
+        .toEqual(new Date(2024, 4, 7, 0, 0, 0, 0));
+    });
+  });
+
+  describe('roundToMinuteOrUndefined', () => {
+    it('gibt undefined für null/undefined zurück', () => {
+      expect(roundToMinuteOrUndefined(null)).toBeUndefined();
+      expect(roundToMinuteOrUndefined(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('nowToMinute', () => {
+    it('liefert einen Zeitstempel ohne Sekundenanteil', () => {
+      const now = nowToMinute();
+      expect(now.getSeconds()).toBe(0);
+      expect(now.getMilliseconds()).toBe(0);
+    });
+  });
+
+  describe('roundMsToMinute', () => {
+    it('rundet kaufmännisch auf volle Minuten', () => {
+      expect(roundMsToMinute(5 * 60000 + 29999)).toBe(5 * 60000);
+      expect(roundMsToMinute(5 * 60000 + 30000)).toBe(6 * 60000);
+    });
+
+    it('rundet negative Werte symmetrisch', () => {
+      expect(roundMsToMinute(-(5 * 60000 + 29999))).toBe(-5 * 60000);
+      expect(roundMsToMinute(-(5 * 60000 + 30000))).toBe(-6 * 60000);
+    });
+  });
+
+  describe('toStoredMinutes', () => {
+    it('gibt gerundete volle Minuten zurück', () => {
+      expect(toStoredMinutes(3600000 + 31000)).toBe(61);
+      expect(toStoredMinutes(-(3600000 + 31000))).toBe(-61);
+    });
+  });
+});

--- a/web/src/app/shared/utils/time-precision.util.ts
+++ b/web/src/app/shared/utils/time-precision.util.ts
@@ -1,0 +1,51 @@
+/**
+ * Zentrale Helfer für die minutengenaue Zeiterfassung.
+ *
+ * Die App erfasst, speichert und rechnet ausschließlich minutengenau.
+ * Sekunden und Millisekunden werden kaufmännisch gerundet (ab 30 Sekunden
+ * auf, darunter ab). So stimmen die angezeigte Uhrzeit (`HH:mm`) und der
+ * Wert, mit dem gerechnet wird, immer überein.
+ */
+
+const MS_PER_MINUTE = 60_000;
+
+/**
+ * Rundet einen Zeitstempel kaufmännisch auf die nächste volle Minute.
+ * `08:00:29` → `08:00`, `08:00:30` → `08:01`.
+ */
+export function roundToMinute(date: Date): Date {
+  return new Date(Math.round(date.getTime() / MS_PER_MINUTE) * MS_PER_MINUTE);
+}
+
+/** Wie {@link roundToMinute}, akzeptiert aber `undefined`/`null`. */
+export function roundToMinuteOrUndefined(date: Date | null | undefined): Date | undefined {
+  return date ? roundToMinute(date) : undefined;
+}
+
+/**
+ * Der aktuelle Zeitpunkt, kaufmännisch auf die volle Minute gerundet.
+ * Einzige Quelle für automatisch erfasste Zeitstempel (Arbeits-/Pausenzeiten).
+ */
+export function nowToMinute(): Date {
+  return roundToMinute(new Date());
+}
+
+/**
+ * Rundet eine Dauer in Millisekunden kaufmännisch auf volle Minuten
+ * und gibt sie wieder in Millisekunden zurück.
+ */
+export function roundMsToMinute(ms: number): number {
+  return toStoredMinutes(ms) * MS_PER_MINUTE;
+}
+
+/**
+ * Eine Dauer in Millisekunden als volle Minuten für die Persistenz.
+ *
+ * Rundet symmetrisch von der Null weg (`+30s` → `+1min`, `-30s` → `-1min`),
+ * damit eine Gleitzeit-Bilanz im Minus nicht anders driftet als im Plus.
+ * `Math.round` allein würde `-0.5` auf `-0` runden.
+ */
+export function toStoredMinutes(ms: number): number {
+  const minutes = ms / MS_PER_MINUTE;
+  return minutes < 0 ? -Math.round(-minutes) : Math.round(minutes);
+}


### PR DESCRIPTION
## Problem

Die App hat Zeiten sekundengenau erfasst, aber überall minutengenau angezeigt. Daraus folgten drei sichtbare Fehler:

1. **Die "fehlende Minute".** Start und Ende wurden als rohes `DateTime.now()` / `new Date()` mit Sekunden gespeichert, aber als `HH:mm` angezeigt. Dauern wurden zusätzlich per `inMinutes` **abgeschnitten** statt gerundet. Beispiel: Start 08:00:59, Ende 16:30:01 → real 8:29:02 → Anzeige „08h 29m", obwohl der Nutzer „08:00 – 16:30" sieht und 8:30 erwartet.

2. **Gemischte Präzision.** Manuell über den TimePicker gesetzte Zeiten waren bereits minutengenau (Sekunden = 0), automatisch getrackte nicht. In derselben Datenbank lagen beide Varianten — ein per Hand korrigierter Tag rechnete anders als ein getrackter.

3. **Driftender Gleitzeit-Saldo.** `saveOvertime` persistierte `overtime.inMinutes`, während der In-Memory-Wert die Sekunden behielt. Zusätzlich runden `Duration.inMinutes` (Richtung Null) und JS-`Math.round` (Richtung +∞) für negative Werte unterschiedlich, d. h. Minus-Salden drifteten anders als Plus-Salden. Über viele Tage summierte sich das auf.

## Lösung

Minutengenauigkeit wird **an der Quelle** erzwungen, nicht erst in der Anzeige — sonst bleiben Daten und Anzeige dauerhaft auseinander. Gerundet wird kaufmännisch (ab 30 s auf), weil das neutral ist: Abschneiden würde beim Start den Arbeitnehmer und beim Ende den Arbeitgeber begünstigen, und der maximale Fehler liegt bei 30 s statt 59 s.

### Neue Helfer

- `mobile/lib/core/utils/time_precision.dart` — `roundToMinute`, `roundToMinuteOrNull`, `nowToMinute`, `roundDurationToMinute`, `toStoredMinutes`
- `web/src/app/shared/utils/time-precision.util.ts` — dieselben Funktionen für Angular

Beide runden negative Dauern symmetrisch von der Null weg, damit sich Mobile und Web identisch verhalten.

### Erfassung

Alle automatisch erfassten Zeitstempel laufen über `nowToMinute()`: Arbeitsbeginn/-ende, neue Session (mit und ohne Pausen), Pause an/aus, Live-Timer und die abgeleiteten Live-Dauern. Manuell gesetzte Zeiten werden defensiv gerundet.

### Persistenz

Die Mapper runden in **beide** Richtungen — `WorkEntryModel`, `BreakModel`, `LocalWorkRepositoryImpl` sowie die Firestore- und localStorage-Pfade im Web. Dadurch werden auch Altdaten mit Sekunden minutengenau gelesen: **kein Migrationslauf nötig**, alte Einträge rechnen ab sofort wie neue.

Der Gleitzeit-Saldo wird gerundet gespeichert, und der Cache im `FirebaseOvertimeRepositoryImpl` hält jetzt denselben Wert wie Firestore (vorher blieben dort die Sekunden liegen).

### Berechnung und Anzeige

Tages-, Wochen- und Monats-Soll sowie die Durchschnittswerte in den Reports runden auf volle Minuten — sonst wären dort wieder Sekundenanteile in die angezeigten Überstunden gelaufen, etwa bei 38 h auf 7 Arbeitstage.

`TimerCard` und der Dashboard-Zähler zeigen `HH:mm` statt `HH:mm:ss` (Mobile und Web). Ein Sekundenzähler wäre bei minutengenauer Datenbasis irreführend.

## Mitgelieferter CI-Fix

Beim Grünmachen der Pipeline kam ein davon unabhängiges Problem hoch, das hier gleich mitbehoben wird: `mockito` zieht transitiv `test_core 0.6.19` herein, das `test_api` exakt auf `0.7.13` pinnt, während das SDK-eigene `flutter_test` exakt `0.7.12` verlangt. Der bestehende Override `test_api: ^0.7.8` war zu locker, um das aufzulösen — die Auflösung landete auf einer `test_api`-Version, deren Interna nicht zu `test_core` passen (`Type 'Declarer' not found`).

Folge: **alle 11 Testdateien mit `*.mocks.dart` ließen sich nicht kompilieren** und wurden von CI als Fehlschlag gemeldet, ohne dass die enthaltenen Tests je liefen. Das galt auch auf `develop` — per Gegenprobe auf dem Basis-Commit bestätigt.

Behoben durch exakte Pins in `mobile/pubspec.yaml`:

```yaml
dependency_overrides:
  test_api: 0.7.12
  test_core: 0.6.18
```

**Hinweis zur Haltbarkeit:** Der Konflikt entstand nur, weil `ci.yml` mit `channel: stable` gegen eine mitwandernde Flutter-Version auflöst. Beim nächsten SDK-Sprung, der `test_api` weiterdreht, brechen die Pins erneut. Die dauerhafte Lösung wäre eine feste `flutter-version` in `ci.yml` — bewusst nicht Teil dieses PRs.

## Tests

Je eine Unit-Test-Datei pro Helfer, inklusive Rundung an der Stunden- und Tagesgrenze sowie negativer Dauern. Der bestehende `timer_card_test` wurde auf das neue Anzeigeformat angepasst.

Weil die 11 Mock-Testdateien vorher gar nicht luden, hatten sie einen Fehler in genau dieser Anpassung verdeckt: die Assertion für die Endzeit war noch auf `HH:mm:ss`. Mit dem Dependency-Fix fiel das sofort auf und ist behoben.

## Verifikation

- Flutter: `flutter analyze --no-fatal-infos` → 0 Fehler (17 vorbestehende `info`-Hinweise). `flutter test` → **169 Tests grün** (vorher liefen nur 107, die übrigen 11 Dateien luden nicht).
- Web: `tsc --noEmit -p tsconfig.app.json` → sauber. Der Produktions-Build läuft nur in CI, weil `environment.ts` mit `rcWebApiKey` dort erst aus Secrets generiert wird.

Nebenbei aufgefallen: Das Web-Projekt hat in `angular.json` kein `test`-Target und kein Test-Runner-Paket. `report-calculator.service.spec.ts` und der neue Spec sind daher aktuell nicht ausführbar — Vitest zu verdrahten wäre eine sinnvolle separate Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F