### PR TITLE
Flutter-Version in CI und Release-Build fest pinnen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,13 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      # Flutter-Version bewusst fest gepinnt statt 'stable' mitwandern zu lassen.
+      # Die exakten Overrides für test_api/test_core in mobile/pubspec.yaml sind an
+      # die test_api-Version gekoppelt, die das flutter_test dieses SDKs verlangt.
+      # Beim Anheben hier müssen die Overrides mitgezogen werden.
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.47.1'
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/flutter-production.yml
+++ b/.github/workflows/flutter-production.yml
@@ -24,9 +24,14 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      # Fest gepinnt und identisch zu ci.yml gehalten: der Release-Build muss
+      # mit demselben SDK laufen, gegen das die Tests in CI grün sind.
+      # Die exakten Overrides für test_api/test_core in mobile/pubspec.yaml sind
+      # an die test_api-Version dieses SDKs gekoppelt und beim Anheben mitzuziehen.
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
+          flutter-version: '3.47.1'
           channel: 'stable'
           cache: true
 


### PR DESCRIPTION
Folge-PR zu #188. Dort wurde ein Dependency-Konflikt behoben, der die Pipeline blockierte — dieser PR beseitigt die Ursache, aus der er entstanden ist.

## Problem

Beide Flutter-Workflows lösen mit `channel: 'stable'` gegen eine mitwandernde SDK-Version auf. Genau daraus entstand der Konflikt in #188: das SDK brachte eine neue `test_api`-Version mit, zu der die transitiv über `mockito` gezogene `test_core`-Version nicht mehr passte. Ergebnis waren 11 nicht kompilierbare Testdateien — ohne dass sich am Code etwas geändert hatte.

Die dort eingeführten exakten Overrides in `mobile/pubspec.yaml`

```yaml
dependency_overrides:
  test_api: 0.7.12
  test_core: 0.6.18
```

sind an die `test_api`-Version gekoppelt, die das `flutter_test` des jeweiligen SDKs verlangt. Solange die SDK-Version floatet, brechen sie beim nächsten stable-Sprung erneut.

## Änderung

`flutter-version: '3.47.1'` in beiden Workflows:

- `.github/workflows/ci.yml`
- `.github/workflows/flutter-production.yml`

`3.47.1` ist die Version, mit der der aktuelle `develop`-Stand verifiziert ist — sie steht im Cache-Key des letzten grünen Laufs von #188 (169 Tests grün).

Der Release-Workflow war bisher ungepinnt und trug dasselbe Risiko wie CI, dort allerdings im ungünstigeren Moment: er erzeugt das AAB für Google Play. Beide laufen jetzt mit demselben SDK, gegen das die Tests grün sind.

An beiden Pin-Stellen steht ein Kommentar, der die Kopplung zu den `dependency_overrides` festhält — wer die Flutter-Version anhebt, muss die Overrides mitziehen. Ohne diesen Hinweis wäre der Zusammenhang beim nächsten Upgrade nicht erkennbar und der Fehler käme genauso verwirrend zurück wie in #188.

## Hinweis

Ein Pin bedeutet, dass Flutter-Updates ab jetzt bewusst nachgezogen werden müssen, statt automatisch mitzulaufen. Das ist hier der Sinn der Sache: reproduzierbare Builds statt stiller Drift. Beim Anheben gehören Flutter-Version und die beiden Overrides in denselben Commit.

Reine Konfigurationsänderung, kein Anwendungscode betroffen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F)_