### PR TITLE
Gradle-Wrapper auf 8.14.3 anheben und AAB-Build testbar machen

### DIFF
--- a/.github/workflows/flutter-production.yml
+++ b/.github/workflows/flutter-production.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Manuell auslösbar, um den AAB-Build auf einem Branch zu verifizieren,
+  # bevor er nach main geht. Der Play-Upload bleibt dabei aus (siehe unten).
+  workflow_dispatch:
 
 defaults:
   run:
@@ -78,7 +81,10 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+      # Nur beim echten Release über main hochladen. Ein manueller Testlauf
+      # (workflow_dispatch) baut das AAB, veröffentlicht es aber nicht.
       - name: Upload to Google Play (Closed Testing)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_JSON_KEY }}

--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip


### PR DESCRIPTION
Behebt den fehlgeschlagenen Android-Production-Build von Release 1.3.0 (#192).

## Was passiert ist

Nach dem Merge von #192 liefen Web- und API-Deploy erfolgreich durch, der Android-Build brach ab. `Analyze` und `Test` waren grün (169 Tests), der AAB-Build scheiterte:

```
> Failed to apply plugin 'dev.flutter.flutter-gradle-plugin'.
   > Your project's Gradle version (8.7.0) is lower than
     Flutter's minimum supported version of 8.14.0.
```

Der Play-Upload wurde übersprungen — **es ist nichts Kaputtes bei Nutzern gelandet**. Die Android-App steht weiterhin auf 1.2.0.

Die „Starting AGP 9+"-Box, die Flutter darunter ausgibt, ist eine Fehldiagnose: AGP ist in `settings.gradle` auf 8.6.1 gepinnt und an diesem Fehler nicht beteiligt.

## Versionswahl

Aus der Kompatibilitätstabelle im Flutter-SDK (`gradle_utils.dart`):

```dart
GradleForAgp(agpMin: '8.5.0', agpMax: '8.6.99', minRequiredGradle: '8.7'),
```

und im Kommentar zu `validateGradleAndAgp`: *„AGP has a minimum version of gradle required but no max starting at AGP version 2.3.0+"*.

Gradle **8.14.3** erfüllt damit beide Bedingungen — Flutters Minimum von 8.14.0 und AGPs Minimum von 8.7 — und AGP 8.6.1 kann unverändert bleiben. Die Distribution ist erreichbar (HTTP 206 auf Range-Request geprüft).

## Ursache — und warum das kein Einzelfall ist

Dieselbe Drift wie zuvor bei `test_api`: Der letzte erfolgreiche Production-Build war am 22. Juni mit einem älteren Flutter. Seitdem ist die Mindestanforderung an Gradle gestiegen, während der Wrapper stehen blieb.

**Der Versions-Pin aus #189 hat das nicht verursacht.** Vorher stand dort `channel: stable`, was heute ebenfalls 3.47.1 auflöst — der Build wäre genauso gescheitert. Der Pin hat den Zustand nur eingefroren und damit sichtbar gemacht.

## Damit es nicht wieder erst beim Deploy auffällt

`flutter-production.yml` lief bisher ausschließlich bei Push auf `main` — der AAB-Build war also grundsätzlich erst nach dem Release überprüfbar. Genau diese Lücke hat hier zugeschlagen.

Der Workflow bekommt deshalb einen `workflow_dispatch`-Trigger, und der Play-Upload wird auf Push nach `main` eingeschränkt:

```yaml
- name: Upload to Google Play (Closed Testing)
  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

Ein manueller Lauf baut das AAB damit vollständig, veröffentlicht es aber nicht. Der Fix wird so vor dem nächsten Release verifizierbar.

## Verifikation

`flutter analyze --no-fatal-infos` ist sauber. Der AAB-Build selbst **konnte ich hier nicht prüfen** — in dieser Umgebung gibt es kein Android-SDK, und `ci.yml` baut kein AAB. Genau dafür ist der `workflow_dispatch`-Trigger da.

**Vorschlag für die Reihenfolge:** Diesen PR nach `develop` mergen, dann den Workflow manuell auf `develop` auslösen. Läuft der AAB-Build durch, geht der Fix per Release nach `main` und der Play-Upload zieht nach. Vorher lässt sich der Trigger nicht nutzen, weil `workflow_dispatch` die Trigger-Definition auf dem Default-Branch braucht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F)_