### PR TITLE
Android-Build auf Gradle 9.3.1 und AGP 9.1.0 heben (neues AGP-DSL)

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -25,19 +25,18 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+// Ab AGP 9 wird ausschließlich das neue DSL gelesen: Eigenschaften werden
+// zugewiesen (`x = y`) statt per Methodenaufruf gesetzt (`x y`), und
+// minSdkVersion/targetSdkVersion heißen minSdk/targetSdk.
 android {
-    namespace "app.work_time_manager"
-    compileSdk flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    namespace = "app.work_time_manager"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-        coreLibraryDesugaringEnabled true
-    }
-
-    kotlinOptions {
-        jvmTarget = '17'
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+        coreLibraryDesugaringEnabled = true
     }
 
     sourceSets {
@@ -45,12 +44,12 @@ android {
     }
 
     defaultConfig {
-        applicationId "app.work_time_manager"
-        minSdkVersion flutter.minSdkVersion
-        targetSdkVersion flutter.targetSdkVersion
+        applicationId = "app.work_time_manager"
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
         // Prioritize environment variable for CI, otherwise use local properties.
-        versionCode System.getenv("VERSION_CODE") != null ? System.getenv("VERSION_CODE").toInteger() : flutterVersionCode.toInteger()
-        versionName flutterVersionName
+        versionCode = System.getenv("VERSION_CODE") != null ? System.getenv("VERSION_CODE").toInteger() : flutterVersionCode.toInteger()
+        versionName = flutterVersionName
     }
 
     signingConfigs {
@@ -58,25 +57,32 @@ android {
             // This configuration reads the signature details from the environment variables
             // set in the GitHub Action.
             if (System.getenv("ORG_GRADLE_PROJECT_android.signing.storeFile") != null) {
-                storeFile file(System.getenv("ORG_GRADLE_PROJECT_android.signing.storeFile"))
-                storePassword System.getenv("ORG_GRADLE_PROJECT_android.signing.storePassword")
-                keyAlias System.getenv("ORG_GRADLE_PROJECT_android.signing.keyAlias")
-                keyPassword System.getenv("ORG_GRADLE_PROJECT_android.signing.keyPassword")
+                storeFile = file(System.getenv("ORG_GRADLE_PROJECT_android.signing.storeFile"))
+                storePassword = System.getenv("ORG_GRADLE_PROJECT_android.signing.storePassword")
+                keyAlias = System.getenv("ORG_GRADLE_PROJECT_android.signing.keyAlias")
+                keyPassword = System.getenv("ORG_GRADLE_PROJECT_android.signing.keyPassword")
             }
         }
     }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
-            minifyEnabled true
-            shrinkResources true
+            signingConfig = signingConfigs.release
+            minifyEnabled = true
+            shrinkResources = true
         }
     }
 }
 
+// kotlinOptions wurde durch die kotlin{}-Erweiterung ersetzt.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
 flutter {
-    source '../..'
+    source = '../..'
 }
 
 dependencies {

--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/mobile/android/settings.gradle
+++ b/mobile/android/settings.gradle
@@ -19,8 +19,9 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    // Stabile und funktionierende Versionen:
-    id "com.android.application" version "8.6.1" apply false
+    // Auf die Kombination, die Flutter 3.47.1 selbst als Template ausliefert
+    // (templateAndroidGradlePluginVersion / templateDefaultGradleVersion).
+    id "com.android.application" version "9.1.0" apply false
     id "com.google.gms.google-services" version "4.4.3" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }


### PR DESCRIPTION
Macht den Android-Release-Build wieder lauffähig. Setzt #193 fort, das die Gradle-Hürde nahm, aber an der nächsten Mindestanforderung hängenblieb.

## ✅ Verifiziert — das AAB baut wieder

Anders als #193 ist dieser Fix **echt geprüft**. Testlauf per `workflow_dispatch` auf diesem Branch:

| Schritt | Ergebnis |
|---|---|
| Build Production AAB | ✅ **success** (~8:47 min) |
| Upload AAB Artifact | ✅ success |
| Upload to Google Play | ⏭️ **skipped** — nichts veröffentlicht |

[Run 32500612729](https://github.com/Riksorax/Work-Time-Manager/actions/runs/32500612729) · Commit `d56709b`

Zum Vergleich: Die gescheiterten Läufe brachen nach 80 bzw. 98 Sekunden ab, bevor überhaupt kompiliert wurde. Knapp neun Minuten sind das erwartete Maß für einen vollständigen Release-Build mit R8 und Resource-Shrinking.

## Warum der große Sprung

Der Lauf nach #193 meldete zwei Dinge gleichzeitig:

```
> Your project's Android Gradle Plugin version (8.6.1) is lower than
  Flutter's minimum supported version of 8.11.1.

Warning: Flutter support for your project's Gradle version (8.14.3)
will soon be dropped. Please upgrade to at least 9.1.0 soon.
```

AGP nur auf das Minimum 8.11.1 zu heben, hätte den Build zwar repariert, aber mit einer bereits abgekündigten Gradle-Version — die nächste Runde wäre absehbar gewesen. Dieser PR geht deshalb auf die Kombination, die Flutter 3.47.1 selbst als Template ausliefert (`templateDefaultGradleVersion` und `templateAndroidGradlePluginVersion` in `gradle_utils.dart`):

| | vorher | jetzt |
|---|---|---|
| Gradle | 8.14.3 | **9.3.1** |
| AGP | 8.6.1 | **9.1.0** |

## DSL-Migration

Ab AGP 9 wird ausschließlich das neue DSL gelesen. `mobile/android/app/build.gradle` ist entsprechend angepasst:

- Eigenschaften werden zugewiesen (`x = y`) statt per Methodenaufruf gesetzt (`x y`) — betrifft `namespace`, `compileSdk`, `ndkVersion`, `compileOptions`, `applicationId`, `versionCode`/`versionName`, `signingConfigs`, `minifyEnabled`, `shrinkResources`, `flutter.source`
- `minSdkVersion`/`targetSdkVersion` heißen jetzt `minSdk`/`targetSdk`
- `kotlinOptions` ist durch die `kotlin { compilerOptions { … } }`-Erweiterung ersetzt

Die Datei bleibt Groovy — die AGP-9-Umstellung betrifft die DSL-Semantik, nicht die Sprache. Eine Konvertierung nach Kotlin-DSL wäre ein separater, deutlich größerer Eingriff.

`google-services` 4.4.3, `kotlin-android` und die `sourceSets`-Syntax funktionieren unverändert mit AGP 9 — das hat der Testlauf bestätigt.

## Korrektur zu #193

Dort stand, AGP 8.6.1 könne bleiben. Das war falsch. Ich hatte die AGP↔Gradle-Tabelle im SDK herangezogen, die aber nur beantwortet, welches Gradle ein gegebenes AGP verlangt — nicht, welches AGP Flutter selbst mindestens fordert. Zwei unabhängige Prüfungen, von denen ich nur eine gesehen hatte.

## Was der `workflow_dispatch`-Trigger gebracht hat

Diese Migration brauchte drei Anläufe: Gradle, dann AGP, dann das DSL. Ohne den in #193 ergänzten Trigger wären das drei fehlgeschlagene Releases gewesen. So waren es drei Testläufe auf einem Branch, ohne dass je etwas bei Nutzern landete.

## Nach dem Merge

Ein Release nach `main` zieht den Play-Upload nach und bringt Android auf 1.3.0. Web und API laufen bereits auf 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F)_