### PR TITLE
Release-Namen für den Play-Store aus dem Branch-Namen setzen

### DIFF
--- a/.github/workflows/flutter-production.yml
+++ b/.github/workflows/flutter-production.yml
@@ -21,6 +21,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Der Release-Name für den Play-Store steht in RELEASE_NAMES.md, gepflegt
+      # von version-bump.yml. Der Branch-Name des Release-Zweigs ist hier nicht
+      # mehr verfügbar, weil dieser Workflow auf main läuft.
+      # Bewusst früh, damit ein fehlender Name nicht erst nach ~9 min Build auffällt.
+      - name: Release-Namen ermitteln
+        id: release_name
+        run: |
+          VERSION=$(grep '^version:' mobile/pubspec.yaml | sed 's/version: *//' | cut -d'+' -f1)
+          CHARACTER=$(awk -F'|' -v v="$VERSION" '
+            /^\|/ {
+              gsub(/^[ \t]+|[ \t]+$/, "", $2)
+              gsub(/^[ \t]+|[ \t]+$/, "", $3)
+              if ($2 == v) { print $3; exit }
+            }' RELEASE_NAMES.md)
+
+          case "$CHARACTER" in ""|"—"*)
+            if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              echo "::error::Für Version $VERSION steht kein Charakter in RELEASE_NAMES.md. Der Release-Branch muss release/v$VERSION-<Charakter> heißen, damit version-bump.yml den Namen einträgt."
+              exit 1
+            fi
+            echo "::warning::Kein Release-Name für Version $VERSION — bei diesem Testlauf ohne Play-Upload unkritisch."
+            exit 0
+            ;;
+          esac
+
+          echo "name=$VERSION $CHARACTER" >> "$GITHUB_OUTPUT"
+          echo "Release-Name: $VERSION $CHARACTER"
+
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
@@ -90,5 +118,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_JSON_KEY }}
           packageName: app.work_time_manager
           releaseFiles: mobile/build/app/outputs/bundle/release/app-release.aab
+          releaseName: ${{ steps.release_name.outputs.name }}
           tracks: alpha
           status: completed

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,21 +18,84 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version and update pubspec.yaml
+      # Der Branch-Name trägt Version und Release-Charakter:
+      #   release/v1.3.2-Roxas        -> 1.3.2 / "Roxas"
+      #   release/v1.4.0-Micky-Maus   -> 1.4.0 / "Micky Maus"
+      # Der Charakter wird hier in RELEASE_NAMES.md festgeschrieben, weil
+      # flutter-production.yml auf main läuft und den Branch-Namen dort nicht
+      # mehr sehen kann.
+      - name: Version und Release-Charakter aus dem Branch lesen
+        id: parse
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
-          VERSION="${BRANCH#release/v}"
+          SUFFIX="${BRANCH#release/v}"
+          VERSION="${SUFFIX%%-*}"
 
+          if [ "$SUFFIX" = "$VERSION" ]; then
+            echo "::error::Branch '$BRANCH' enthält keinen Release-Charakter. Erwartet wird release/v<Version>-<Charakter>, z. B. release/v1.3.2-Roxas. Freie Namen stehen in RELEASE_NAMES.md."
+            exit 1
+          fi
+
+          CHARACTER=$(printf '%s' "${SUFFIX#*-}" | tr '-' ' ')
+          echo "version=$VERSION"     >> "$GITHUB_OUTPUT"
+          echo "character=$CHARACTER" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION — Charakter: $CHARACTER"
+
+      - name: Charakter prüfen und in RELEASE_NAMES.md eintragen
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          CHARACTER: ${{ steps.parse.outputs.character }}
+        run: |
+          python3 - <<'PY'
+          import datetime, os, re, sys
+
+          path = "RELEASE_NAMES.md"
+          version = os.environ["VERSION"]
+          character = os.environ["CHARACTER"]
+          lines = open(path, encoding="utf-8").read().split("\n")
+
+          free_idx = [i for i, l in enumerate(lines) if l.strip() == f"- {character}"]
+          used = [l for l in lines if l.startswith("|") and l.split("|")[2].strip() == character]
+
+          if used:
+              sys.exit(f"::error::Der Charakter '{character}' ist bereits vergeben. Freie Namen stehen in {path}.")
+          if not free_idx:
+              sys.exit(f"::error::'{character}' steht nicht in der Frei-Liste von {path}. Entweder ist der Name falsch geschrieben oder er muss dort ergänzt werden.")
+
+          # Bereits eingetragen (z. B. erneuter Push auf denselben Branch)?
+          if any(l.startswith("|") and l.split("|")[1].strip() == version for l in lines):
+              print(f"Version {version} steht bereits in {path} — nichts zu tun.")
+              sys.exit(0)
+
+          today = datetime.date.today().isoformat()
+          sep = next(i for i, l in enumerate(lines) if re.match(r"^\|\s*---", l))
+          lines.insert(sep + 1, f"| {version} | {character} | {today} |")
+          # Index verschiebt sich durch das Einfügen um eins
+          lines.pop(free_idx[0] + 1)
+
+          open(path, "w", encoding="utf-8").write("\n".join(lines))
+          print(f"'{character}' als {version} eingetragen.")
+          PY
+
+      - name: pubspec.yaml aktualisieren und committen
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          CHARACTER: ${{ steps.parse.outputs.character }}
+        run: |
           CURRENT=$(grep '^version:' mobile/pubspec.yaml | sed 's/version: //')
-          if [ "$CURRENT" = "$VERSION" ]; then
-            echo "Version already $VERSION — nothing to do"
+          if [ "$CURRENT" != "$VERSION" ]; then
+            sed -i "s/^version: .*/version: $VERSION/" mobile/pubspec.yaml
+          else
+            echo "Version steht bereits auf $VERSION"
+          fi
+
+          if git diff --quiet; then
+            echo "Keine Änderungen — nichts zu committen"
             exit 0
           fi
 
-          sed -i "s/^version: .*/version: $VERSION/" mobile/pubspec.yaml
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add mobile/pubspec.yaml
-          git commit -m "chore(release): bump version to $VERSION [skip ci]"
+          git add mobile/pubspec.yaml RELEASE_NAMES.md
+          git commit -m "chore(release): bump version to $VERSION ($CHARACTER) [skip ci]"
           git push

--- a/RELEASE_NAMES.md
+++ b/RELEASE_NAMES.md
@@ -1,0 +1,106 @@
+# Release-Namen
+
+Jedes Release im geschlossenen Test (Play-Track `alpha`) trägt den Namen
+`<Version> <Charakter>` — der Charakter stammt aus Kingdom Hearts.
+
+## Wie ein Name vergeben wird
+
+Der Charakter kommt aus dem Namen des Release-Branches:
+
+```
+release/v1.3.2-Roxas          ->  Release-Name "1.3.2 Roxas"
+release/v1.4.0-Micky-Maus     ->  Release-Name "1.4.0 Micky Maus"
+```
+
+Alles vor dem ersten `-` ist die Version, alles danach der Charakter;
+Bindestriche im Charakternamen werden zu Leerzeichen.
+
+`version-bump.yml` prüft beim Push auf den Release-Branch, ob der Charakter
+unter „Noch frei" steht, verschiebt ihn nach „Vergeben" und committet das
+zusammen mit der Versionsnummer. `flutter-production.yml` liest den Namen
+später aus der Tabelle unten und übergibt ihn beim Play-Upload — der
+Branch-Name ist zu diesem Zeitpunkt nicht mehr verfügbar, weil der Workflow
+auf `main` läuft.
+
+Steht der Charakter nicht in der Frei-Liste, bricht der Bump mit einer
+Fehlermeldung ab. Namen werden also nie doppelt vergeben.
+
+## Vergeben
+
+| Version | Charakter | Datum |
+| --- | --- | --- |
+| 1.3.1 | — | 2026-08-21 |
+| 1.1.0 | Micky Maus | 2026-05-25 |
+| 1.0.0 | Sora | 2026-05-13 |
+| 0.24.1 | Chirithy | 2026-03-15 |
+| 0.13.3 | Xion | 2025-10-26 |
+| 0.11.1 | Namine | 2025-10-26 |
+| 0.06.0 | Ventus | 2025-10-21 |
+| 0.05.0 | Terra | 2025-10-19 |
+| 0.03.0 | Aqua | 2025-10-04 |
+| 0.02.3 | Kairi | 2025-09-30 |
+| 0.02.2 | Riku | 2025-09-30 |
+
+> Die Einträge vor 1.3.1 sind aus der Play Console rekonstruiert. Zwischen
+> Chirithy und Xion liegt mindestens ein weiteres Release (14.03.2026), dessen
+> Name nicht ablesbar war — bitte bei Gelegenheit ergänzen und den betreffenden
+> Charakter unten aus der Frei-Liste entfernen.
+>
+> 1.3.1 ging als „alpha" heraus, weil der Workflow damals noch keinen
+> Release-Namen übergab. Genau das behebt diese Änderung.
+
+## Noch frei
+
+- Roxas
+- Axel
+- Lea
+- Isa
+- Saix
+- Xemnas
+- Xigbar
+- Xaldin
+- Vexen
+- Lexaeus
+- Zexion
+- Larxene
+- Marluxia
+- Luxord
+- Demyx
+- Xehanort
+- Ansem
+- Vanitas
+- Eraqus
+- Ienzo
+- Even
+- Aeleus
+- Dilan
+- Braig
+- Donald
+- Goofy
+- Minnie Maus
+- Daisy
+- Pluto
+- Chip
+- Chap
+- Jiminy
+- Yen Sid
+- Merlin
+- Cid
+- Leon
+- Yuffie
+- Aerith
+- Tifa
+- Cloud
+- Sephiroth
+- Strelitzia
+- Ephemer
+- Skuld
+- Lauriam
+- Elrena
+- Brain
+- Ava
+- Invi
+- Gula
+- Aced
+- Ira
+- Luxu


### PR DESCRIPTION
Release 1.3.1 ging als **„alpha"** in den geschlossenen Test, statt dem gewohnten Muster `<Version> <Kingdom-Hearts-Charakter>` zu folgen. Grund: Der Workflow übergab keinen `releaseName`, also nimmt Play den Track-Namen als Fallback.

## Wie der Name jetzt entsteht

Der Charakter kommt aus dem Namen des Release-Branches:

```
release/v1.3.2-Roxas        ->  "1.3.2 Roxas"
release/v1.4.0-Micky-Maus   ->  "1.4.0 Micky Maus"
```

Alles vor dem ersten Bindestrich ist die Version, alles danach der Charakter; Bindestriche darin werden zu Leerzeichen.

### Warum eine Datei dazwischenliegt

`flutter-production.yml` läuft bei Push auf `main` — der Branch-Name des Release-Zweigs ist dort nicht mehr verfügbar. Der Name muss den Merge also überstehen.

Deshalb schreibt `version-bump.yml` ihn in **`RELEASE_NAMES.md`**. Die Datei wandert per Release-Merge nach `main`, wo der Play-Upload den Namen zur passenden Version wieder ausliest. Dieselbe Datei ist zugleich die Übersicht, welche Charaktere vergeben sind und welche noch frei — beides in einer Quelle, ohne Möglichkeit zum Auseinanderlaufen.

## Prüfungen beim Bump

| Fall | Verhalten |
|---|---|
| Branch ohne Charakter (`release/v1.5.0`) | Abbruch mit Hinweis auf das erwartete Format |
| Charakter bereits vergeben (`Sora`) | Abbruch |
| Charakter nicht in der Frei-Liste | Abbruch |
| Alles in Ordnung | Wandert von „Noch frei" nach „Vergeben", wird mit der Version committet |

Namen können damit nicht doppelt vergeben werden, und ein vergessener Charakter fällt sofort auf — nicht erst im Play-Store.

## Fail-fast beim Build

`flutter-production.yml` ermittelt den Namen **direkt nach dem Checkout**, nicht erst beim Upload. Ein fehlender Eintrag bricht damit nach Sekunden ab statt nach rund neun Minuten Build.

Bei einem Testlauf per `workflow_dispatch` bleibt es bei einer Warnung — dort wird ohnehin nicht veröffentlicht, und ein harter Abbruch würde die Verifikations-Schleife unbrauchbar machen.

## Lokal durchgespielt

Beide Mechanismen sind fehleranfällig genug, dass ich sie vor dem Commit simuliert habe:

- Branch-Parsing für alle drei Fälle inklusive `Micky-Maus` → `Micky Maus`
- Eintrag von `Roxas` als 1.3.2: landet oben in der Tabelle, verschwindet aus der Frei-Liste, Nachbareinträge unberührt
- Rück-Lookup findet `Roxas` für 1.3.2
- Fehlerfälle `Sora` (vergeben) und `Bugs Bunny` (unbekannt) brechen mit der richtigen Meldung ab

Dabei fiel ein echter Fehler auf: Die Zelle für 1.3.1 lautete zunächst `— (ohne Namen veröffentlicht)`, womit der Guard sie nicht als „kein Name" erkannt hätte. Der Release-Name wäre dann buchstäblich `1.3.1 — (ohne Namen veröffentlicht)` geworden. Die Zelle ist jetzt nur `—`, und der Guard greift auf jedes führende `—`.

## Zur Liste

Die Tabelle ist aus deinen Play-Console-Screenshots rekonstruiert: Riku, Kairi, Aqua, Terra, Ventus, Naminé, Xion, Chirithy, Sora, Micky Maus. **Ein Release vom 14.03.2026 war nicht lesbar** und fehlt — der Hinweis steht in der Datei, bitte bei Gelegenheit ergänzen und den Charakter aus der Frei-Liste nehmen.

1.3.1 steht mit `—` drin, weil es bereits unbenannt veröffentlicht wurde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F)_