### PR TITLE
main nach develop zurückmergen (Version 1.3.1)

### DIFF
--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.0
+version: 1.3.1
 
 environment:
   sdk: '>=3.1.0 <4.0.0'

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0
+version: 1.3.0
 
 environment:
   sdk: '>=3.1.0 <4.0.0'


### PR DESCRIPTION
Räumt die letzte offene Baustelle nach den Releases 1.3.0 und 1.3.1 auf.

## Problem

`develop` steht auf Version **1.2.0**, `main` auf **1.3.1**. Grund: `version-bump.yml` setzt die Versionsnummer nur auf dem Release-Branch, und der wird nach `main` gemergt — nicht zurück nach `develop`.

Dasselbe Muster ließ die Version schon nach dem 1.2.0-Release auf 1.1.0 hängen. Beim Anlegen von `release/v1.3.1` musste ich deshalb erst `main` in den Release-Branch mergen, damit der Bump auf 1.3.1 nicht mit `main`s 1.3.0 in derselben Zeile kollidiert. Ohne Rückmerge wiederholt sich dieser Umweg bei jedem Release.

## Änderung

Merge von `main` nach `develop`. **Konfliktfrei**, und der inhaltliche Effekt beschränkt sich auf eine Zeile:

```
mobile/pubspec.yaml | 2 +-
```

1.2.0 → 1.3.1.

Die fünf Commits aus `main` (zwei Release-Merges, zwei Versions-Bumps, ein Zwischenmerge) sind damit in `develop` enthalten.

## Was erhalten bleibt

Die Release-Namen-Logik aus #196 liegt bislang nur auf `develop` und wird vom Merge nicht angetastet — `releaseName` im Production-Workflow und `RELEASE_NAMES.md` sind unverändert vorhanden. Nach diesem PR ist `develop` inhaltlich eine echte Obermenge von `main`.

## Danach

Der nächste Release-Branch kann direkt von `develop` abzweigen, ohne vorher `main` hineinzumergen:

```
release/v1.3.2-Roxas
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F)_