### PR TITLE
RELEASE_NAMES.md gegen die Play Console abgleichen

### DIFF
--- a/RELEASE_NAMES.md
+++ b/RELEASE_NAMES.md
@@ -8,7 +8,7 @@ Jedes Release im geschlossenen Test (Play-Track `alpha`) trägt den Namen
 Der Charakter kommt aus dem Namen des Release-Branches:
 
 ```
-release/v1.3.2-Roxas          ->  Release-Name "1.3.2 Roxas"
+release/v1.3.2-Vanitas        ->  Release-Name "1.3.2 Vanitas"
 release/v1.4.0-Micky-Maus     ->  Release-Name "1.4.0 Micky Maus"
 ```
 
@@ -31,9 +31,14 @@ Fehlermeldung ab. Namen werden also nie doppelt vergeben.
 | --- | --- | --- |
 | 1.3.1 | — | 2026-08-21 |
 | 1.1.0 | Micky Maus | 2026-05-25 |
-| 1.0.0 | Sora | 2026-05-13 |
+| 0.24.1 | Sora | 2026-05-13 |
 | 0.24.1 | Chirithy | 2026-03-15 |
-| 0.13.3 | Xion | 2025-10-26 |
+| 0.24.0 | Axel | 2026-03-14 |
+| 0.18.1 | Ansem the Wise | 2026-01-07 |
+| 0.17.0 | Xemnas | 2025-12-31 |
+| 0.16.0 | Master Xehanort | 2025-12-30 |
+| 0.15.0 | Roxas | 2025-12-30 |
+| 0.13.3 | Xion | 2025-12-22 |
 | 0.11.1 | Namine | 2025-10-26 |
 | 0.06.0 | Ventus | 2025-10-21 |
 | 0.05.0 | Terra | 2025-10-19 |
@@ -41,34 +46,34 @@ Fehlermeldung ab. Namen werden also nie doppelt vergeben.
 | 0.02.3 | Kairi | 2025-09-30 |
 | 0.02.2 | Riku | 2025-09-30 |
 
-> Die Einträge vor 1.3.1 sind aus der Play Console rekonstruiert. Zwischen
-> Chirithy und Xion liegt mindestens ein weiteres Release (14.03.2026), dessen
-> Name nicht ablesbar war — bitte bei Gelegenheit ergänzen und den betreffenden
-> Charakter unten aus der Frei-Liste entfernen.
+> Zwei Anmerkungen zu den Altdaten:
 >
-> 1.3.1 ging als „alpha" heraus, weil der Workflow damals noch keinen
-> Release-Namen übergab. Genau das behebt diese Änderung.
+> - Der Release-Name von Sora lautet in der Console „0.24.1 Sora", die
+>   App-Version war jedoch 1.0.0. Die Versionsspalte gibt hier den
+>   Release-Namen wieder, nicht die App-Version — deshalb steht 0.24.1
+>   zweimal in der Tabelle.
+> - 1.3.1 ging als „Alpha" heraus, weil der Workflow damals noch keinen
+>   Release-Namen übergab. Genau das ist inzwischen behoben.
 
 ## Noch frei
 
-- Roxas
-- Axel
-- Lea
-- Isa
-- Saix
-- Xemnas
-- Xigbar
-- Xaldin
-- Vexen
-- Lexaeus
-- Zexion
+Einige Einträge sind alternative Identitäten derselben Figur (Lea/Axel,
+Isa/Saix). Ist eine Variante vergeben, sollte die andere nicht mehr
+verwendet werden, auch wenn die Prüfung sie formal durchlässt.
+
+- Vanitas
 - Larxene
 - Marluxia
 - Luxord
 - Demyx
-- Xehanort
-- Ansem
-- Vanitas
+- Zexion
+- Lexaeus
+- Vexen
+- Xigbar
+- Xaldin
+- Saix
+- Isa
+- Lea
 - Eraqus
 - Ienzo
 - Even


### PR DESCRIPTION
Die Liste war aus Screenshots rekonstruiert. Der vollständige Auszug aus dem geschlossenen Test deckt **drei Fehler** auf — zwei davon hätten echten Schaden angerichtet.

## Drei bereits vergebene Namen standen als frei

| Charakter | Tatsächlich vergeben als |
|---|---|
| **Roxas** | 0.15.0 (30.12.2025) |
| **Xemnas** | 0.17.0 (31.12.2025) |
| **Axel** | 0.24.0 (14.03.2026) |

Der Bump hätte alle drei anstandslos durchgelassen und ein zweites Release mit demselben Namen erzeugt — genau der Fall, den die Prüfung eigentlich verhindern soll. Sie kann nur so gut sein wie die Liste.

**Roxas war zusätzlich das Beispiel in der Dokumentation** und im PR-Text von #196. Wer sich daran orientiert hätte, wäre direkt in den Doppelnamen gelaufen. Das Beispiel ist jetzt `Vanitas`.

## Falsches Datum

Xion stand mit dem Datum von Naminé (26.10.2025). Tatsächlich: **22.12.2025**.

## Fünf fehlende Releases

Nicht nur die bekannte Lücke vom 14.03.2026, sondern vier weitere: Roxas (0.15.0), Master Xehanort (0.16.0), Xemnas (0.17.0), Ansem the Wise (0.18.1) und Axel (0.24.0).

Die Tabelle umfasst jetzt **alle 16 Releases** des geschlossenen Tests.

## Zwei Dinge, die die Prüfung grundsätzlich nicht erkennt

**Zu ähnliche Namen.** `Xehanort` und `Ansem` standen als frei, während `Master Xehanort` und `Ansem the Wise` vergeben sind. Formal verschiedene Strings, praktisch dieselbe Figur — beide aus der Frei-Liste entfernt.

**Alternative Identitäten.** Lea ist Axel, Isa ist Saïx. Da Axel vergeben ist, sollte Lea nicht mehr verwendet werden. Automatisch prüfbar ist das nicht, deshalb steht jetzt ein Hinweis über der Frei-Liste.

## Sora

Der Release-Name lautet `0.24.1 Sora`, die App-Version war aber 1.0.0. Die Versionsspalte gibt den Release-Namen wieder — dadurch steht 0.24.1 zweimal in der Tabelle. Als Anmerkung festgehalten, damit es nicht später als Fehler gelesen wird.

## Verifikation

- Keine Überschneidung mehr zwischen „Vergeben" (16) und „Noch frei" (48)
- Lookup findet die neuen Einträge: `0.24.0` → `Axel`, `0.15.0` → `Roxas`
- `1.3.1` liefert weiterhin `—` und wird korrekt als „kein Name" behandelt
- Bump-Simulation trägt `Vanitas` als 1.3.2 ein und entfernt ihn aus der Frei-Liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAthHhmp8UXNVrqqDN9Y4F)_