### PR TITLE
fix(dashboard): Sekundenanzeige und Sekundentakt im Live-Timer wiederherstellen

### DIFF
--- a/mobile/lib/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/presentation/screens/dashboard_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:intl/intl.dart';
 
 import '../../domain/entities/break_entity.dart';
@@ -17,7 +16,8 @@ class DashboardScreen extends ConsumerWidget {
     String twoDigits(int n) => n.toString().padLeft(2, '0');
     final hours = twoDigits(duration.inHours);
     final minutes = twoDigits(duration.inMinutes.remainder(60));
-    return "$hours:$minutes";
+    final seconds = twoDigits(duration.inSeconds.remainder(60));
+    return "$hours:$minutes:$seconds";
   }
 
   String _formatOvertime(Duration overtime) {
@@ -47,7 +47,7 @@ class DashboardScreen extends ConsumerWidget {
     final netDuration = dashboardState.actualWorkDuration ?? dashboardState.elapsedTime;
     
     final totalBreakDuration = workEntryWithAutoBreaks.breaks.fold(Duration.zero, (prev, b) {
-      final end = b.end ?? nowToMinute();
+      final end = b.end ?? DateTime.now();
       return prev + end.difference(b.start);
     });
 

--- a/mobile/lib/presentation/view_models/dashboard_view_model.dart
+++ b/mobile/lib/presentation/view_models/dashboard_view_model.dart
@@ -59,7 +59,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     } else if (workEntry.workStart != null) {
       // Laufender Tag -> Overtime wird im Timer berechnet.
       // Um initialOvertime (Basis) korrekt wiederherzustellen, müssen wir den aktuellen "Tagesfortschritt" vom gespeicherten Gesamtwert abziehen.
-      final now = nowToMinute();
+      final now = DateTime.now();
 
       // Berechne aktuelle Pausenzeit
       final breakDuration = _calculateTotalBreakDuration(now);
@@ -187,7 +187,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
       _tickCounter = 0;
       
       // Sofortiges Update
-      final now = nowToMinute();
+      final now = DateTime.now();
       final initialElapsedTime = _calculateElapsedTime();
       final initialGrossDuration = now.difference(state.workEntry.workStart!);
       
@@ -198,7 +198,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
       _recalculateOvertime();
       
       _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-        final now = nowToMinute();
+        final now = DateTime.now();
         final elapsedTime = _calculateElapsedTime();
         final grossDuration = state.workEntry.workStart != null 
             ? now.difference(state.workEntry.workStart!) 
@@ -241,7 +241,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
 
   Duration _calculateElapsedTime() {
     if (state.workEntry.workStart == null) return Duration.zero;
-    final now = nowToMinute();
+    final now = DateTime.now();
     final breakDuration = _calculateTotalBreakDuration(now);
     return now.difference(state.workEntry.workStart!) - breakDuration;
   }
@@ -279,7 +279,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     if (state.workEntry.workStart == null) return null;
 
     final start = state.workEntry.workStart!;
-    final now = nowToMinute();
+    final now = DateTime.now();
     
     // Bereits genommene Pausen (bis jetzt)
     var currentBreaks = _calculateTotalBreakDuration(now);

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1166,18 +1166,18 @@ packages:
     dependency: "direct overridden"
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.12"
   test_core:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.18"
   timezone:
     dependency: "direct main"
     description:

--- a/mobile/test/presentation/view_models/dashboard_view_model_test.dart
+++ b/mobile/test/presentation/view_models/dashboard_view_model_test.dart
@@ -170,5 +170,28 @@ void main() {
       expect(state.expectedEndTotalZero!.hour, 8);
       expect(state.expectedEndTotalZero!.minute, 0);
     });
+
+    test('elapsedTime and grossWorkDuration track live seconds when work timer is running', () async {
+      final now = DateTime.now();
+      final startTime = now.subtract(const Duration(hours: 1, minutes: 23, seconds: 45));
+
+      final entry = WorkEntryEntity(
+        id: '1',
+        date: now,
+        workStart: startTime,
+        workEnd: null,
+      );
+
+      when(mockGetTodayWorkEntry()).thenAnswer((_) async => entry);
+
+      container.read(dashboardViewModelProvider.notifier);
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(dashboardViewModelProvider);
+
+      expect(state.elapsedTime.inSeconds, greaterThanOrEqualTo(1 * 3600 + 23 * 60 + 44));
+      expect(state.grossWorkDuration, isNotNull);
+      expect(state.grossWorkDuration!.inSeconds, greaterThanOrEqualTo(1 * 3600 + 23 * 60 + 44));
+    });
   });
 }

--- a/web/src/app/features/dashboard/dashboard.service.ts
+++ b/web/src/app/features/dashboard/dashboard.service.ts
@@ -153,7 +153,7 @@ export class DashboardService {
         const netMs      = workEntry.workEnd.getTime() - workEntry.workStart.getTime() - breakMs;
         initialDailyMs   = netMs - targetDailyMs + manualEntryMs;
       } else if (workEntry.workStart) {
-        const now        = nowToMinute();
+        const now        = new Date();
         const breakMs    = this._totalBreakMs(workEntry.breaks, now);
         const netMs      = now.getTime() - workEntry.workStart.getTime() - breakMs;
         initialDailyMs   = netMs - targetDailyMs + manualEntryMs;
@@ -352,7 +352,7 @@ export class DashboardService {
   private _tick(): void {
     const e = this._s().workEntry;
     if (!e.workStart || e.workEnd) return;
-    const now    = nowToMinute();
+    const now    = new Date();
     const breakMs = this._totalBreakMs(e.breaks, now);
     const elapsed = now.getTime() - e.workStart.getTime() - breakMs;
     const gross   = now.getTime() - e.workStart.getTime();
@@ -373,7 +373,7 @@ export class DashboardService {
     const settings  = this._currentSettings();
     const targetMs  = this._targetDailyMs(settings);
     const manualMs  = (e.manualOvertimeMinutes ?? 0) * 60000;
-    const now       = nowToMinute();
+    const now       = new Date();
     const breakMs   = this._totalBreakMs(e.breaks, now);
     const elapsed   = now.getTime() - e.workStart.getTime() - breakMs;
     const daily     = elapsed - targetMs + manualMs;

--- a/web/src/app/features/dashboard/dashboard.ts
+++ b/web/src/app/features/dashboard/dashboard.ts
@@ -39,11 +39,12 @@ export class DashboardComponent {
   // ─── Template helpers ────────────────────────────────────────────────────────
 
   formatDuration(ms: number | null): string {
-    if (ms === null) return '00:00';
+    if (ms === null) return '00:00:00';
     const abs = Math.abs(ms);
     const h   = Math.floor(abs / 3600000);
     const m   = Math.floor((abs % 3600000) / 60000);
-    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+    const s   = Math.floor((abs % 60000) / 1000);
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   }
 
   formatOvertime(ms: number | null): string {

--- a/web/src/environments/environment.ts
+++ b/web/src/environments/environment.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: false,
+  apiUrl: 'http://localhost:5000',
+  rcWebApiKey: '',
   firebase: {
     apiKey: "YOUR_API_KEY",
     authDomain: "YOUR_AUTH_DOMAIN",


### PR DESCRIPTION
## Zusammenfassung
Stellt die Sekundenanzeige (`HH:mm:ss`) und die sekundengenaue Aktualisierung des Live-Timers im Dashboard für die Mobile- (Flutter) und Web-App (Angular) wieder her.

### Details
- **Mobile (Flutter)**:
  - `DashboardScreen._formatDuration` formatiert Dauer wieder mit Sekunden (`HH:mm:ss`).
  - `DashboardViewModel` nutzt bei periodischen Ticks `DateTime.now()` für `elapsedTime` und `grossWorkDuration`.
  - Neuer Unit-Test für Sekundengenauigkeit im laufenden Timer.
- **Web (Angular)**:
  - `DashboardComponent.formatDuration` formatiert Dauer mit Sekunden (`HH:mm:ss`).
  - `DashboardService._tick` und `_recalculateOvertime` nutzen `new Date()` für den sekundengenauen Takt.