### PR TITLE
Release/1.3.2 (Vanitas)

### DIFF
--- a/.github/workflows/flutter-production.yml
+++ b/.github/workflows/flutter-production.yml
@@ -21,6 +21,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Der Release-Name für den Play-Store steht in RELEASE_NAMES.md, gepflegt
+      # von version-bump.yml. Der Branch-Name des Release-Zweigs ist hier nicht
+      # mehr verfügbar, weil dieser Workflow auf main läuft.
+      # Bewusst früh, damit ein fehlender Name nicht erst nach ~9 min Build auffällt.
+      - name: Release-Namen ermitteln
+        id: release_name
+        run: |
+          VERSION=$(grep '^version:' mobile/pubspec.yaml | sed 's/version: *//' | cut -d'+' -f1)
+          CHARACTER=$(awk -F'|' -v v="$VERSION" '
+            /^\|/ {
+              gsub(/^[ \t]+|[ \t]+$/, "", $2)
+              gsub(/^[ \t]+|[ \t]+$/, "", $3)
+              if ($2 == v) { print $3; exit }
+            }' RELEASE_NAMES.md)
+
+          case "$CHARACTER" in ""|"—"*)
+            if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+              echo "::error::Für Version $VERSION steht kein Charakter in RELEASE_NAMES.md. Der Release-Branch muss release/v$VERSION-<Charakter> heißen, damit version-bump.yml den Namen einträgt."
+              exit 1
+            fi
+            echo "::warning::Kein Release-Name für Version $VERSION — bei diesem Testlauf ohne Play-Upload unkritisch."
+            exit 0
+            ;;
+          esac
+
+          echo "name=$VERSION $CHARACTER" >> "$GITHUB_OUTPUT"
+          echo "Release-Name: $VERSION $CHARACTER"
+
       - name: Set up Java 17
         uses: actions/setup-java@v4
         with:
@@ -90,5 +118,6 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_STORE_JSON_KEY }}
           packageName: app.work_time_manager
           releaseFiles: mobile/build/app/outputs/bundle/release/app-release.aab
+          releaseName: ${{ steps.release_name.outputs.name }}
           tracks: alpha
           status: completed

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,21 +18,84 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version and update pubspec.yaml
+      # Der Branch-Name trägt Version und Release-Charakter:
+      #   release/v1.3.2-Roxas        -> 1.3.2 / "Roxas"
+      #   release/v1.4.0-Micky-Maus   -> 1.4.0 / "Micky Maus"
+      # Der Charakter wird hier in RELEASE_NAMES.md festgeschrieben, weil
+      # flutter-production.yml auf main läuft und den Branch-Namen dort nicht
+      # mehr sehen kann.
+      - name: Version und Release-Charakter aus dem Branch lesen
+        id: parse
         run: |
           BRANCH="${GITHUB_REF#refs/heads/}"
-          VERSION="${BRANCH#release/v}"
+          SUFFIX="${BRANCH#release/v}"
+          VERSION="${SUFFIX%%-*}"
 
+          if [ "$SUFFIX" = "$VERSION" ]; then
+            echo "::error::Branch '$BRANCH' enthält keinen Release-Charakter. Erwartet wird release/v<Version>-<Charakter>, z. B. release/v1.3.2-Roxas. Freie Namen stehen in RELEASE_NAMES.md."
+            exit 1
+          fi
+
+          CHARACTER=$(printf '%s' "${SUFFIX#*-}" | tr '-' ' ')
+          echo "version=$VERSION"     >> "$GITHUB_OUTPUT"
+          echo "character=$CHARACTER" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION — Charakter: $CHARACTER"
+
+      - name: Charakter prüfen und in RELEASE_NAMES.md eintragen
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          CHARACTER: ${{ steps.parse.outputs.character }}
+        run: |
+          python3 - <<'PY'
+          import datetime, os, re, sys
+
+          path = "RELEASE_NAMES.md"
+          version = os.environ["VERSION"]
+          character = os.environ["CHARACTER"]
+          lines = open(path, encoding="utf-8").read().split("\n")
+
+          free_idx = [i for i, l in enumerate(lines) if l.strip() == f"- {character}"]
+          used = [l for l in lines if l.startswith("|") and l.split("|")[2].strip() == character]
+
+          if used:
+              sys.exit(f"::error::Der Charakter '{character}' ist bereits vergeben. Freie Namen stehen in {path}.")
+          if not free_idx:
+              sys.exit(f"::error::'{character}' steht nicht in der Frei-Liste von {path}. Entweder ist der Name falsch geschrieben oder er muss dort ergänzt werden.")
+
+          # Bereits eingetragen (z. B. erneuter Push auf denselben Branch)?
+          if any(l.startswith("|") and l.split("|")[1].strip() == version for l in lines):
+              print(f"Version {version} steht bereits in {path} — nichts zu tun.")
+              sys.exit(0)
+
+          today = datetime.date.today().isoformat()
+          sep = next(i for i, l in enumerate(lines) if re.match(r"^\|\s*---", l))
+          lines.insert(sep + 1, f"| {version} | {character} | {today} |")
+          # Index verschiebt sich durch das Einfügen um eins
+          lines.pop(free_idx[0] + 1)
+
+          open(path, "w", encoding="utf-8").write("\n".join(lines))
+          print(f"'{character}' als {version} eingetragen.")
+          PY
+
+      - name: pubspec.yaml aktualisieren und committen
+        env:
+          VERSION: ${{ steps.parse.outputs.version }}
+          CHARACTER: ${{ steps.parse.outputs.character }}
+        run: |
           CURRENT=$(grep '^version:' mobile/pubspec.yaml | sed 's/version: //')
-          if [ "$CURRENT" = "$VERSION" ]; then
-            echo "Version already $VERSION — nothing to do"
+          if [ "$CURRENT" != "$VERSION" ]; then
+            sed -i "s/^version: .*/version: $VERSION/" mobile/pubspec.yaml
+          else
+            echo "Version steht bereits auf $VERSION"
+          fi
+
+          if git diff --quiet; then
+            echo "Keine Änderungen — nichts zu committen"
             exit 0
           fi
 
-          sed -i "s/^version: .*/version: $VERSION/" mobile/pubspec.yaml
-
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add mobile/pubspec.yaml
-          git commit -m "chore(release): bump version to $VERSION [skip ci]"
+          git add mobile/pubspec.yaml RELEASE_NAMES.md
+          git commit -m "chore(release): bump version to $VERSION ($CHARACTER) [skip ci]"
           git push

--- a/RELEASE_NAMES.md
+++ b/RELEASE_NAMES.md
@@ -29,6 +29,7 @@ Fehlermeldung ab. Namen werden also nie doppelt vergeben.
 
 | Version | Charakter | Datum |
 | --- | --- | --- |
+| 1.3.2 | Vanitas | 2026-08-24 |
 | 1.3.1 | — | 2026-08-21 |
 | 1.1.0 | Micky Maus | 2026-05-25 |
 | 0.24.1 | Sora | 2026-05-13 |
@@ -61,7 +62,6 @@ Einige Einträge sind alternative Identitäten derselben Figur (Lea/Axel,
 Isa/Saix). Ist eine Variante vergeben, sollte die andere nicht mehr
 verwendet werden, auch wenn die Prüfung sie formal durchlässt.
 
-- Vanitas
 - Larxene
 - Marluxia
 - Luxord

--- a/RELEASE_NAMES.md
+++ b/RELEASE_NAMES.md
@@ -1,0 +1,106 @@
+# Release-Namen
+
+Jedes Release im geschlossenen Test (Play-Track `alpha`) trägt den Namen
+`<Version> <Charakter>` — der Charakter stammt aus Kingdom Hearts.
+
+## Wie ein Name vergeben wird
+
+Der Charakter kommt aus dem Namen des Release-Branches:
+
+```
+release/v1.3.2-Roxas          ->  Release-Name "1.3.2 Roxas"
+release/v1.4.0-Micky-Maus     ->  Release-Name "1.4.0 Micky Maus"
+```
+
+Alles vor dem ersten `-` ist die Version, alles danach der Charakter;
+Bindestriche im Charakternamen werden zu Leerzeichen.
+
+`version-bump.yml` prüft beim Push auf den Release-Branch, ob der Charakter
+unter „Noch frei" steht, verschiebt ihn nach „Vergeben" und committet das
+zusammen mit der Versionsnummer. `flutter-production.yml` liest den Namen
+später aus der Tabelle unten und übergibt ihn beim Play-Upload — der
+Branch-Name ist zu diesem Zeitpunkt nicht mehr verfügbar, weil der Workflow
+auf `main` läuft.
+
+Steht der Charakter nicht in der Frei-Liste, bricht der Bump mit einer
+Fehlermeldung ab. Namen werden also nie doppelt vergeben.
+
+## Vergeben
+
+| Version | Charakter | Datum |
+| --- | --- | --- |
+| 1.3.1 | — | 2026-08-21 |
+| 1.1.0 | Micky Maus | 2026-05-25 |
+| 1.0.0 | Sora | 2026-05-13 |
+| 0.24.1 | Chirithy | 2026-03-15 |
+| 0.13.3 | Xion | 2025-10-26 |
+| 0.11.1 | Namine | 2025-10-26 |
+| 0.06.0 | Ventus | 2025-10-21 |
+| 0.05.0 | Terra | 2025-10-19 |
+| 0.03.0 | Aqua | 2025-10-04 |
+| 0.02.3 | Kairi | 2025-09-30 |
+| 0.02.2 | Riku | 2025-09-30 |
+
+> Die Einträge vor 1.3.1 sind aus der Play Console rekonstruiert. Zwischen
+> Chirithy und Xion liegt mindestens ein weiteres Release (14.03.2026), dessen
+> Name nicht ablesbar war — bitte bei Gelegenheit ergänzen und den betreffenden
+> Charakter unten aus der Frei-Liste entfernen.
+>
+> 1.3.1 ging als „alpha" heraus, weil der Workflow damals noch keinen
+> Release-Namen übergab. Genau das behebt diese Änderung.
+
+## Noch frei
+
+- Roxas
+- Axel
+- Lea
+- Isa
+- Saix
+- Xemnas
+- Xigbar
+- Xaldin
+- Vexen
+- Lexaeus
+- Zexion
+- Larxene
+- Marluxia
+- Luxord
+- Demyx
+- Xehanort
+- Ansem
+- Vanitas
+- Eraqus
+- Ienzo
+- Even
+- Aeleus
+- Dilan
+- Braig
+- Donald
+- Goofy
+- Minnie Maus
+- Daisy
+- Pluto
+- Chip
+- Chap
+- Jiminy
+- Yen Sid
+- Merlin
+- Cid
+- Leon
+- Yuffie
+- Aerith
+- Tifa
+- Cloud
+- Sephiroth
+- Strelitzia
+- Ephemer
+- Skuld
+- Lauriam
+- Elrena
+- Brain
+- Ava
+- Invi
+- Gula
+- Aced
+- Ira
+- Luxu

--- a/RELEASE_NAMES.md
+++ b/RELEASE_NAMES.md
@@ -8,7 +8,7 @@ Jedes Release im geschlossenen Test (Play-Track `alpha`) trägt den Namen
 Der Charakter kommt aus dem Namen des Release-Branches:
 
 ```
-release/v1.3.2-Roxas          ->  Release-Name "1.3.2 Roxas"
+release/v1.3.2-Vanitas        ->  Release-Name "1.3.2 Vanitas"
 release/v1.4.0-Micky-Maus     ->  Release-Name "1.4.0 Micky Maus"
 ```
 
@@ -31,9 +31,14 @@ Fehlermeldung ab. Namen werden also nie doppelt vergeben.
 | --- | --- | --- |
 | 1.3.1 | — | 2026-08-21 |
 | 1.1.0 | Micky Maus | 2026-05-25 |
-| 1.0.0 | Sora | 2026-05-13 |
+| 0.24.1 | Sora | 2026-05-13 |
 | 0.24.1 | Chirithy | 2026-03-15 |
-| 0.13.3 | Xion | 2025-10-26 |
+| 0.24.0 | Axel | 2026-03-14 |
+| 0.18.1 | Ansem the Wise | 2026-01-07 |
+| 0.17.0 | Xemnas | 2025-12-31 |
+| 0.16.0 | Master Xehanort | 2025-12-30 |
+| 0.15.0 | Roxas | 2025-12-30 |
+| 0.13.3 | Xion | 2025-12-22 |
 | 0.11.1 | Namine | 2025-10-26 |
 | 0.06.0 | Ventus | 2025-10-21 |
 | 0.05.0 | Terra | 2025-10-19 |
@@ -41,34 +46,34 @@ Fehlermeldung ab. Namen werden also nie doppelt vergeben.
 | 0.02.3 | Kairi | 2025-09-30 |
 | 0.02.2 | Riku | 2025-09-30 |
 
-> Die Einträge vor 1.3.1 sind aus der Play Console rekonstruiert. Zwischen
-> Chirithy und Xion liegt mindestens ein weiteres Release (14.03.2026), dessen
-> Name nicht ablesbar war — bitte bei Gelegenheit ergänzen und den betreffenden
-> Charakter unten aus der Frei-Liste entfernen.
+> Zwei Anmerkungen zu den Altdaten:
 >
-> 1.3.1 ging als „alpha" heraus, weil der Workflow damals noch keinen
-> Release-Namen übergab. Genau das behebt diese Änderung.
+> - Der Release-Name von Sora lautet in der Console „0.24.1 Sora", die
+>   App-Version war jedoch 1.0.0. Die Versionsspalte gibt hier den
+>   Release-Namen wieder, nicht die App-Version — deshalb steht 0.24.1
+>   zweimal in der Tabelle.
+> - 1.3.1 ging als „Alpha" heraus, weil der Workflow damals noch keinen
+>   Release-Namen übergab. Genau das ist inzwischen behoben.
 
 ## Noch frei
 
-- Roxas
-- Axel
-- Lea
-- Isa
-- Saix
-- Xemnas
-- Xigbar
-- Xaldin
-- Vexen
-- Lexaeus
-- Zexion
+Einige Einträge sind alternative Identitäten derselben Figur (Lea/Axel,
+Isa/Saix). Ist eine Variante vergeben, sollte die andere nicht mehr
+verwendet werden, auch wenn die Prüfung sie formal durchlässt.
+
+- Vanitas
 - Larxene
 - Marluxia
 - Luxord
 - Demyx
-- Xehanort
-- Ansem
-- Vanitas
+- Zexion
+- Lexaeus
+- Vexen
+- Xigbar
+- Xaldin
+- Saix
+- Isa
+- Lea
 - Eraqus
 - Ienzo
 - Even

--- a/mobile/lib/presentation/screens/dashboard_screen.dart
+++ b/mobile/lib/presentation/screens/dashboard_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_work_time/core/utils/time_precision.dart';
 import 'package:intl/intl.dart';
 
 import '../../domain/entities/break_entity.dart';
@@ -17,7 +16,8 @@ class DashboardScreen extends ConsumerWidget {
     String twoDigits(int n) => n.toString().padLeft(2, '0');
     final hours = twoDigits(duration.inHours);
     final minutes = twoDigits(duration.inMinutes.remainder(60));
-    return "$hours:$minutes";
+    final seconds = twoDigits(duration.inSeconds.remainder(60));
+    return "$hours:$minutes:$seconds";
   }
 
   String _formatOvertime(Duration overtime) {
@@ -47,7 +47,7 @@ class DashboardScreen extends ConsumerWidget {
     final netDuration = dashboardState.actualWorkDuration ?? dashboardState.elapsedTime;
     
     final totalBreakDuration = workEntryWithAutoBreaks.breaks.fold(Duration.zero, (prev, b) {
-      final end = b.end ?? nowToMinute();
+      final end = b.end ?? DateTime.now();
       return prev + end.difference(b.start);
     });
 

--- a/mobile/lib/presentation/view_models/dashboard_view_model.dart
+++ b/mobile/lib/presentation/view_models/dashboard_view_model.dart
@@ -59,7 +59,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     } else if (workEntry.workStart != null) {
       // Laufender Tag -> Overtime wird im Timer berechnet.
       // Um initialOvertime (Basis) korrekt wiederherzustellen, müssen wir den aktuellen "Tagesfortschritt" vom gespeicherten Gesamtwert abziehen.
-      final now = nowToMinute();
+      final now = DateTime.now();
 
       // Berechne aktuelle Pausenzeit
       final breakDuration = _calculateTotalBreakDuration(now);
@@ -187,7 +187,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
       _tickCounter = 0;
       
       // Sofortiges Update
-      final now = nowToMinute();
+      final now = DateTime.now();
       final initialElapsedTime = _calculateElapsedTime();
       final initialGrossDuration = now.difference(state.workEntry.workStart!);
       
@@ -198,7 +198,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
       _recalculateOvertime();
       
       _timer = Timer.periodic(const Duration(seconds: 1), (_) {
-        final now = nowToMinute();
+        final now = DateTime.now();
         final elapsedTime = _calculateElapsedTime();
         final grossDuration = state.workEntry.workStart != null 
             ? now.difference(state.workEntry.workStart!) 
@@ -241,7 +241,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
 
   Duration _calculateElapsedTime() {
     if (state.workEntry.workStart == null) return Duration.zero;
-    final now = nowToMinute();
+    final now = DateTime.now();
     final breakDuration = _calculateTotalBreakDuration(now);
     return now.difference(state.workEntry.workStart!) - breakDuration;
   }
@@ -279,7 +279,7 @@ class DashboardViewModel extends Notifier<DashboardState> {
     if (state.workEntry.workStart == null) return null;
 
     final start = state.workEntry.workStart!;
-    final now = nowToMinute();
+    final now = DateTime.now();
     
     // Bereits genommene Pausen (bis jetzt)
     var currentBreaks = _calculateTotalBreakDuration(now);

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1166,18 +1166,18 @@ packages:
     dependency: "direct overridden"
     description:
       name: test_api
-      sha256: "19a78f63e83d3a61f00826d09bc2f60e191bf3504183c001262be6ac75589fb8"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.8"
+    version: "0.7.12"
   test_core:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: test_core
-      sha256: f1072617a6657e5fc09662e721307f7fb009b4ed89b19f47175d11d5254a62d4
+      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.14"
+    version: "0.6.18"
   timezone:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.1
+version: 1.3.2
 
 environment:
   sdk: '>=3.1.0 <4.0.0'

--- a/mobile/test/presentation/view_models/dashboard_view_model_test.dart
+++ b/mobile/test/presentation/view_models/dashboard_view_model_test.dart
@@ -170,5 +170,28 @@ void main() {
       expect(state.expectedEndTotalZero!.hour, 8);
       expect(state.expectedEndTotalZero!.minute, 0);
     });
+
+    test('elapsedTime and grossWorkDuration track live seconds when work timer is running', () async {
+      final now = DateTime.now();
+      final startTime = now.subtract(const Duration(hours: 1, minutes: 23, seconds: 45));
+
+      final entry = WorkEntryEntity(
+        id: '1',
+        date: now,
+        workStart: startTime,
+        workEnd: null,
+      );
+
+      when(mockGetTodayWorkEntry()).thenAnswer((_) async => entry);
+
+      container.read(dashboardViewModelProvider.notifier);
+      await Future.delayed(Duration.zero);
+
+      final state = container.read(dashboardViewModelProvider);
+
+      expect(state.elapsedTime.inSeconds, greaterThanOrEqualTo(1 * 3600 + 23 * 60 + 44));
+      expect(state.grossWorkDuration, isNotNull);
+      expect(state.grossWorkDuration!.inSeconds, greaterThanOrEqualTo(1 * 3600 + 23 * 60 + 44));
+    });
   });
 }

--- a/web/src/app/features/dashboard/dashboard.service.ts
+++ b/web/src/app/features/dashboard/dashboard.service.ts
@@ -153,7 +153,7 @@ export class DashboardService {
         const netMs      = workEntry.workEnd.getTime() - workEntry.workStart.getTime() - breakMs;
         initialDailyMs   = netMs - targetDailyMs + manualEntryMs;
       } else if (workEntry.workStart) {
-        const now        = nowToMinute();
+        const now        = new Date();
         const breakMs    = this._totalBreakMs(workEntry.breaks, now);
         const netMs      = now.getTime() - workEntry.workStart.getTime() - breakMs;
         initialDailyMs   = netMs - targetDailyMs + manualEntryMs;
@@ -352,7 +352,7 @@ export class DashboardService {
   private _tick(): void {
     const e = this._s().workEntry;
     if (!e.workStart || e.workEnd) return;
-    const now    = nowToMinute();
+    const now    = new Date();
     const breakMs = this._totalBreakMs(e.breaks, now);
     const elapsed = now.getTime() - e.workStart.getTime() - breakMs;
     const gross   = now.getTime() - e.workStart.getTime();
@@ -373,7 +373,7 @@ export class DashboardService {
     const settings  = this._currentSettings();
     const targetMs  = this._targetDailyMs(settings);
     const manualMs  = (e.manualOvertimeMinutes ?? 0) * 60000;
-    const now       = nowToMinute();
+    const now       = new Date();
     const breakMs   = this._totalBreakMs(e.breaks, now);
     const elapsed   = now.getTime() - e.workStart.getTime() - breakMs;
     const daily     = elapsed - targetMs + manualMs;

--- a/web/src/app/features/dashboard/dashboard.ts
+++ b/web/src/app/features/dashboard/dashboard.ts
@@ -39,11 +39,12 @@ export class DashboardComponent {
   // ─── Template helpers ────────────────────────────────────────────────────────
 
   formatDuration(ms: number | null): string {
-    if (ms === null) return '00:00';
+    if (ms === null) return '00:00:00';
     const abs = Math.abs(ms);
     const h   = Math.floor(abs / 3600000);
     const m   = Math.floor((abs % 3600000) / 60000);
-    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+    const s   = Math.floor((abs % 60000) / 1000);
+    return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   }
 
   formatOvertime(ms: number | null): string {

--- a/web/src/environments/environment.ts
+++ b/web/src/environments/environment.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: false,
+  apiUrl: 'http://localhost:5000',
+  rcWebApiKey: '',
   firebase: {
     apiKey: "YOUR_API_KEY",
     authDomain: "YOUR_AUTH_DOMAIN",


### PR DESCRIPTION
## Release 1.3.2 — Vanitas

### Highlights & Bugfixes
- **Dashboard**: Sekundenanzeige (`HH:mm:ss`) und Sekundentakt im Live-Timer für Flutter-Mobile und Angular-Web wiederhergestellt (#199).
- **Minutengenauigkeit**: Persistenz- und Speichermodelle bleiben minutengenau wie spezifiziert.
- **Version**: Bump auf Version `1.3.2` mit Release-Namen **Vanitas**.