### PR TITLE
ci: Deploy Flutter AAB in benannten geschlossenen Test-Track (<Version> <Charakter>)

### DIFF
--- a/.github/workflows/flutter-production.yml
+++ b/.github/workflows/flutter-production.yml
@@ -7,6 +7,11 @@ on:
   # Manuell auslösbar, um den AAB-Build auf einem Branch zu verifizieren,
   # bevor er nach main geht. Der Play-Upload bleibt dabei aus (siehe unten).
   workflow_dispatch:
+    inputs:
+      track_name:
+        description: 'Google Play Track / Release Name (optional, überschreibt RELEASE_NAMES.md)'
+        required: false
+        default: ''
 
 defaults:
   run:
@@ -21,14 +26,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # Der Release-Name für den Play-Store steht in RELEASE_NAMES.md, gepflegt
+      # Der Release- und Track-Name für den Play-Store steht in RELEASE_NAMES.md, gepflegt
       # von version-bump.yml. Der Branch-Name des Release-Zweigs ist hier nicht
       # mehr verfügbar, weil dieser Workflow auf main läuft.
       # Bewusst früh, damit ein fehlender Name nicht erst nach ~9 min Build auffällt.
-      - name: Release-Namen ermitteln
+      - name: Release- und Track-Namen ermitteln
         id: release_name
         working-directory: .
         run: |
+          OVERRIDE="${{ github.event.inputs.track_name }}"
+          if [ -n "$OVERRIDE" ]; then
+            echo "name=$OVERRIDE" >> "$GITHUB_OUTPUT"
+            echo "Release- und Track-Name (aus Input): $OVERRIDE"
+            exit 0
+          fi
+
           VERSION=$(grep '^version:' mobile/pubspec.yaml | sed 's/version: *//' | cut -d'+' -f1)
           CHARACTER=$(awk -F'|' -v v="$VERSION" '
             /^\|/ {
@@ -48,7 +60,7 @@ jobs:
           esac
 
           echo "name=$VERSION $CHARACTER" >> "$GITHUB_OUTPUT"
-          echo "Release-Name: $VERSION $CHARACTER"
+          echo "Release- und Track-Name: $VERSION $CHARACTER"
 
       - name: Set up Java 17
         uses: actions/setup-java@v4
@@ -120,5 +132,5 @@ jobs:
           packageName: app.work_time_manager
           releaseFiles: mobile/build/app/outputs/bundle/release/app-release.aab
           releaseName: ${{ steps.release_name.outputs.name }}
-          tracks: alpha
+          track: ${{ steps.release_name.outputs.name }}
           status: completed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ npm run build -- --configuration production
 
 | Workflow | Trigger | Jobs |
 |---|---|---|
-| `flutter-production.yml` | Push to `main` | Android AAB → Google Play (Closed Testing) |
+| `flutter-production.yml` | Push to `main` oder `workflow_dispatch` | Android AAB → Google Play (Closed Testing Track `<Version> <Charakter>` aus `RELEASE_NAMES.md` oder Input) |
 | `deploy-angular.yml` | Push to `main` oder `workflow_dispatch` | 1. Angular Build → 2. Docker Image → Docker Hub → 3. Deploy → Hetzner |
 | `deploy-api.yml` | Push to `main` oder `workflow_dispatch` | 1. .NET Build & Test → 2. Docker Image → Docker Hub → 3. Deploy → Hetzner |
 | `ci.yml` | PRs / Push | Lint & Tests |

--- a/RELEASE_NAMES.md
+++ b/RELEASE_NAMES.md
@@ -1,26 +1,30 @@
 # Release-Namen
-
-Jedes Release im geschlossenen Test (Play-Track `alpha`) trägt den Namen
+ 
+Jedes Release im geschlossenen Test (Play-Track `<Version> <Charakter>`) trägt den Namen
 `<Version> <Charakter>` — der Charakter stammt aus Kingdom Hearts.
-
+ 
 ## Wie ein Name vergeben wird
-
+ 
 Der Charakter kommt aus dem Namen des Release-Branches:
-
+ 
 ```
-release/v1.3.2-Vanitas        ->  Release-Name "1.3.2 Vanitas"
-release/v1.4.0-Micky-Maus     ->  Release-Name "1.4.0 Micky Maus"
+release/v1.3.2-Vanitas        ->  Release- und Track-Name "1.3.2 Vanitas"
+release/v1.4.0-Micky-Maus     ->  Release- und Track-Name "1.4.0 Micky Maus"
 ```
-
+ 
 Alles vor dem ersten `-` ist die Version, alles danach der Charakter;
 Bindestriche im Charakternamen werden zu Leerzeichen.
-
+ 
 `version-bump.yml` prüft beim Push auf den Release-Branch, ob der Charakter
 unter „Noch frei" steht, verschiebt ihn nach „Vergeben" und committet das
 zusammen mit der Versionsnummer. `flutter-production.yml` liest den Namen
-später aus der Tabelle unten und übergibt ihn beim Play-Upload — der
-Branch-Name ist zu diesem Zeitpunkt nicht mehr verfügbar, weil der Workflow
-auf `main` läuft.
+später aus der Tabelle unten und übergibt ihn beim Play-Upload als `track` und
+`releaseName` — der Branch-Name ist zu diesem Zeitpunkt nicht mehr verfügbar,
+weil der Workflow auf `main` läuft.
+ 
+> **Wichtig:** Der geschlossene Test-Track mit dem Namen `<Version> <Charakter>`
+> (z. B. `1.3.2 Vanitas`) muss vorab in der Google Play Console unter
+> *Testen > Geschlossene Tests* erstellt und mit Testern verknüpft sein!
 
 Steht der Charakter nicht in der Frei-Liste, bricht der Bump mit einer
 Fehlermeldung ab. Namen werden also nie doppelt vergeben.


### PR DESCRIPTION
## Zusammenfassung

- **Automatischer Track-Name:** `.github/workflows/flutter-production.yml` liest Version und Charakter (z. B. `1.3.2 Vanitas`) aus `RELEASE_NAMES.md` und übergibt diesen Wert nun sowohl als `releaseName` als auch als `track` an die Play Store Upload Action.
- **Manueller Override:** `workflow_dispatch` wurde um das optionale Eingabefeld `track_name` erweitert, um bei Bedarf manuell in einen abweichenden Track zu deployen.
- **Dokumentation:** `RELEASE_NAMES.md` und `CLAUDE.md` aktualisiert mit dem Hinweis, dass der geschlossene Test-Track in der Google Play Console vorab angelegt sein muss.
